### PR TITLE
Feature/add benchmarks

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -38,8 +38,8 @@ jobs:
         id: bazel-cache
         uses: actions/cache@v3
         with:
-          path: ~/.cache/bazel
-          key: ${{ runner.os }}-bazel-cache-${{ hashFiles('**/*.bazel') }}
+          path: /home/runner/.cache/bazel
+          key: ${{ runner.os }}-bazel-cache
           restore-keys: |
             ${{ runner.os }}-bazel-cache-
 
@@ -50,11 +50,11 @@ jobs:
             -v ${{ github.workspace }}:/workspaces/ctmd \
             -v /home/runner/.cache/bazel:/root/.cache/bazel \
             ctmd-dev:latest \
-            bash -c "cd /workspaces/ctmd && pwd && ls -la && bazel build //... && bazel test //..."
+            bash -c "cd /workspaces/ctmd && pwd && ls -la && bazel test //..."
 
       # Save Bazel cache
       - name: Save Bazel cache
         uses: actions/cache@v3
         with:
-          path: ~/.cache/bazel
-          key: ${{ runner.os }}-bazel-cache-${{ hashFiles('**/*.bazel') }}
+          path: /home/runner/.cache/bazel
+          key: ${{ runner.os }}-bazel-cache

--- a/benchmarks/add/cpump/raw/source.hpp
+++ b/benchmarks/add/cpump/raw/source.hpp
@@ -9,14 +9,14 @@ constexpr size_t RANGE_MULTIPLIER = 10;
 template <typename T> inline void test(benchmark::State &state) noexcept {
     const size_t set_num = state.range(0);
 
-    auto a = std::vector<T>(set_num, 1);
-    auto b = std::vector<T>(set_num, 2);
-    auto c = std::vector<T>(set_num, 0);
+    const auto in1 = std::vector<T>(set_num, 1);
+    const auto in2 = std::vector<T>(set_num, 2);
+    auto out = std::vector<T>(set_num, 0);
 
     for (auto _ : state) {
 #pragma omp parallel for
         for (size_t i = 0; i < set_num; i++) {
-            c[i] = a[i] + b[i];
+            out[i] = in1[i] + in2[i];
         }
     }
 

--- a/benchmarks/add/cpump/source.hpp
+++ b/benchmarks/add/cpump/source.hpp
@@ -12,12 +12,12 @@ constexpr size_t RANGE_MULTIPLIER = 10;
 template <typename T> inline void test(benchmark::State &state) noexcept {
     const size_t set_num = state.range(0);
 
-    const auto a = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
-    const auto b = md::full<T, md::dims<1>>(2, md::dims<1>{set_num});
-    auto c = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
+    const auto in1 = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+    const auto in2 = md::full<T, md::dims<1>>(2, md::dims<1>{set_num});
+    auto out = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
 
     for (auto _ : state) {
-        md::add(a, b, c, md::MPMode::CPUMP);
+        md::add(in1, in2, out, md::MPMode::CPUMP);
     }
 
     state.SetComplexityN(state.range(0));

--- a/benchmarks/add/gpump/raw/source.hpp
+++ b/benchmarks/add/gpump/raw/source.hpp
@@ -9,27 +9,27 @@ constexpr size_t RANGE_MULTIPLIER = 10;
 template <typename T> inline void test(benchmark::State &state) noexcept {
     const size_t set_num = state.range(0);
 
-    auto a = std::vector<T>(set_num, 1);
-    auto b = std::vector<T>(set_num, 2);
-    auto c = std::vector<T>(set_num, 0);
+    const auto in1 = std::vector<T>(set_num, 1);
+    const auto in2 = std::vector<T>(set_num, 2);
+    auto out = std::vector<T>(set_num, 0);
 
-    T *pa = a.data();
-    T *pb = b.data();
-    T *pc = c.data();
+    T *p1 = in1.data();
+    T *p2 = in2.data();
+    T *po = out.data();
 
-#pragma omp target enter data map(to : pa[0 : set_num], pb[0 : set_num])       \
-    map(alloc : pc[0 : set_num])
+#pragma omp target enter data map(to : p1[0 : set_num], p2[0 : set_num])       \
+    map(alloc : po[0 : set_num])
 
     for (auto _ : state) {
 #pragma omp target teams distribute parallel for nowait map(                   \
-        to : pa[0 : set_num], pb[0 : set_num]) map(from : pc[0 : set_num])
+        to : p1[0 : set_num], p2[0 : set_num]) map(from : po[0 : set_num])
         for (size_t i = 0; i < set_num; i++) {
-            pc[i] = pa[i] + pb[i];
+            po[i] = p1[i] + p2[i];
         }
     }
 
-#pragma omp target exit data map(delete : pa[0 : set_num], pb[0 : set_num],    \
-                                     pc[0 : set_num])
+#pragma omp target exit data map(delete : p1[0 : set_num], p2[0 : set_num],    \
+                                     po[0 : set_num])
 
     state.SetComplexityN(state.range(0));
 }

--- a/benchmarks/add/gpump/source.hpp
+++ b/benchmarks/add/gpump/source.hpp
@@ -12,12 +12,12 @@ constexpr size_t RANGE_MULTIPLIER = 10;
 template <typename T> inline void test(benchmark::State &state) noexcept {
     const size_t set_num = state.range(0);
 
-    const auto a = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
-    const auto b = md::full<T, md::dims<1>>(2, md::dims<1>{set_num});
-    auto c = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
+    const auto in1 = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+    const auto in2 = md::full<T, md::dims<1>>(2, md::dims<1>{set_num});
+    auto out = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
 
     for (auto _ : state) {
-        md::add(a, b, c, md::MPMode::GPUMP);
+        md::add(in1, in2, out, md::MPMode::GPUMP);
     }
 
     state.SetComplexityN(state.range(0));

--- a/benchmarks/add/raw/source.hpp
+++ b/benchmarks/add/raw/source.hpp
@@ -9,13 +9,13 @@ constexpr size_t RANGE_MULTIPLIER = 10;
 template <typename T> inline void test(benchmark::State &state) noexcept {
     const size_t set_num = state.range(0);
 
-    auto a = std::vector<T>(set_num, 1);
-    auto b = std::vector<T>(set_num, 2);
-    auto c = std::vector<T>(set_num, 0);
+    const auto in1 = std::vector<T>(set_num, 1);
+    const auto in2 = std::vector<T>(set_num, 2);
+    auto out = std::vector<T>(set_num, 0);
 
     for (auto _ : state) {
         for (size_t i = 0; i < set_num; i++) {
-            c[i] = a[i] + b[i];
+            out[i] = in1[i] + in2[i];
         }
     }
 

--- a/benchmarks/add/source.hpp
+++ b/benchmarks/add/source.hpp
@@ -12,12 +12,12 @@ constexpr size_t RANGE_MULTIPLIER = 10;
 template <typename T> inline void test(benchmark::State &state) noexcept {
     const size_t set_num = state.range(0);
 
-    const auto a = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
-    const auto b = md::full<T, md::dims<1>>(2, md::dims<1>{set_num});
-    auto c = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
+    const auto in1 = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+    const auto in2 = md::full<T, md::dims<1>>(2, md::dims<1>{set_num});
+    auto out = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
 
     for (auto _ : state) {
-        md::add(a, b, c);
+        md::add(in1, in2, out);
     }
 
     state.SetComplexityN(state.range(0));

--- a/benchmarks/all/BUILD.bazel
+++ b/benchmarks/all/BUILD.bazel
@@ -1,0 +1,189 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu8",
+    srcs = [
+        "source.hpp",
+        "epu8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu16",
+    srcs = [
+        "source.hpp",
+        "epu16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu32",
+    srcs = [
+        "source.hpp",
+        "epu32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu64",
+    srcs = [
+        "source.hpp",
+        "epu64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/all/epi16.cpp
+++ b/benchmarks/all/epi16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/all/epi32.cpp
+++ b/benchmarks/all/epi32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/all/epi64.cpp
+++ b/benchmarks/all/epi64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/all/epi8.cpp
+++ b/benchmarks/all/epi8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/all/epu16.cpp
+++ b/benchmarks/all/epu16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/all/epu32.cpp
+++ b/benchmarks/all/epu32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/all/epu64.cpp
+++ b/benchmarks/all/epu64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/all/epu8.cpp
+++ b/benchmarks/all/epu8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/all/pd.cpp
+++ b/benchmarks/all/pd.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/all/ps.cpp
+++ b/benchmarks/all/ps.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/all/source.hpp
+++ b/benchmarks/all/source.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 1e8;
+constexpr size_t RANGE_MULTIPLIER = 10;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    const auto in = md::full<T, md::dims<1>>(true, md::dims<1>{set_num});
+
+    for (auto _ : state) {
+        const auto out = md::all(in);
+        benchmark::DoNotOptimize(out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/allclose/BUILD.bazel
+++ b/benchmarks/allclose/BUILD.bazel
@@ -1,0 +1,113 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/allclose/epi16.cpp
+++ b/benchmarks/allclose/epi16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/allclose/epi32.cpp
+++ b/benchmarks/allclose/epi32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/allclose/epi64.cpp
+++ b/benchmarks/allclose/epi64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/allclose/epi8.cpp
+++ b/benchmarks/allclose/epi8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/allclose/pd.cpp
+++ b/benchmarks/allclose/pd.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/allclose/ps.cpp
+++ b/benchmarks/allclose/ps.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/allclose/source.hpp
+++ b/benchmarks/allclose/source.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 1e8;
+constexpr size_t RANGE_MULTIPLIER = 10;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    const auto in1 = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+    const auto in2 = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+
+    for (auto _ : state) {
+        const auto out = md::allclose(in1, in2);
+        benchmark::DoNotOptimize(out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/array_equal/BUILD.bazel
+++ b/benchmarks/array_equal/BUILD.bazel
@@ -1,0 +1,189 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu8",
+    srcs = [
+        "source.hpp",
+        "epu8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu16",
+    srcs = [
+        "source.hpp",
+        "epu16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu32",
+    srcs = [
+        "source.hpp",
+        "epu32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu64",
+    srcs = [
+        "source.hpp",
+        "epu64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/array_equal/epi16.cpp
+++ b/benchmarks/array_equal/epi16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/array_equal/epi32.cpp
+++ b/benchmarks/array_equal/epi32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/array_equal/epi64.cpp
+++ b/benchmarks/array_equal/epi64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/array_equal/epi8.cpp
+++ b/benchmarks/array_equal/epi8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/array_equal/epu16.cpp
+++ b/benchmarks/array_equal/epu16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/array_equal/epu32.cpp
+++ b/benchmarks/array_equal/epu32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/array_equal/epu64.cpp
+++ b/benchmarks/array_equal/epu64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/array_equal/epu8.cpp
+++ b/benchmarks/array_equal/epu8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/array_equal/pd.cpp
+++ b/benchmarks/array_equal/pd.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/array_equal/ps.cpp
+++ b/benchmarks/array_equal/ps.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/array_equal/source.hpp
+++ b/benchmarks/array_equal/source.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 1e8;
+constexpr size_t RANGE_MULTIPLIER = 10;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    const auto in1 = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+    const auto in2 = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+
+    for (auto _ : state) {
+        const auto out = md::array_equal(in1, in2);
+        benchmark::DoNotOptimize(out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/clip/BUILD.bazel
+++ b/benchmarks/clip/BUILD.bazel
@@ -1,0 +1,189 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu8",
+    srcs = [
+        "source.hpp",
+        "epu8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu16",
+    srcs = [
+        "source.hpp",
+        "epu16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu32",
+    srcs = [
+        "source.hpp",
+        "epu32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu64",
+    srcs = [
+        "source.hpp",
+        "epu64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/clip/epi16.cpp
+++ b/benchmarks/clip/epi16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/clip/epi32.cpp
+++ b/benchmarks/clip/epi32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/clip/epi64.cpp
+++ b/benchmarks/clip/epi64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/clip/epi8.cpp
+++ b/benchmarks/clip/epi8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/clip/epu16.cpp
+++ b/benchmarks/clip/epu16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/clip/epu32.cpp
+++ b/benchmarks/clip/epu32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/clip/epu64.cpp
+++ b/benchmarks/clip/epu64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/clip/epu8.cpp
+++ b/benchmarks/clip/epu8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/clip/pd.cpp
+++ b/benchmarks/clip/pd.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/clip/ps.cpp
+++ b/benchmarks/clip/ps.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/clip/source.hpp
+++ b/benchmarks/clip/source.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 1e8;
+constexpr size_t RANGE_MULTIPLIER = 10;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    const auto in = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+    const auto min = md::full<T, md::dims<1>>(2, md::dims<1>{set_num});
+    const auto max = md::full<T, md::dims<1>>(3, md::dims<1>{set_num});
+    auto out = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
+
+    for (auto _ : state) {
+        md::clip(in, min, max, out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/copy/BUILD.bazel
+++ b/benchmarks/copy/BUILD.bazel
@@ -1,0 +1,189 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu8",
+    srcs = [
+        "source.hpp",
+        "epu8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu16",
+    srcs = [
+        "source.hpp",
+        "epu16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu32",
+    srcs = [
+        "source.hpp",
+        "epu32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu64",
+    srcs = [
+        "source.hpp",
+        "epu64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/copy/epi16.cpp
+++ b/benchmarks/copy/epi16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/copy/epi32.cpp
+++ b/benchmarks/copy/epi32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/copy/epi64.cpp
+++ b/benchmarks/copy/epi64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/copy/epi8.cpp
+++ b/benchmarks/copy/epi8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/copy/epu16.cpp
+++ b/benchmarks/copy/epu16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/copy/epu32.cpp
+++ b/benchmarks/copy/epu32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/copy/epu64.cpp
+++ b/benchmarks/copy/epu64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/copy/epu8.cpp
+++ b/benchmarks/copy/epu8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/copy/pd.cpp
+++ b/benchmarks/copy/pd.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/copy/ps.cpp
+++ b/benchmarks/copy/ps.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/copy/source.hpp
+++ b/benchmarks/copy/source.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 1e8;
+constexpr size_t RANGE_MULTIPLIER = 10;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    const auto in = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+    auto out = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
+
+    for (auto _ : state) {
+        md::copy(in, out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/divide/BUILD.bazel
+++ b/benchmarks/divide/BUILD.bazel
@@ -1,0 +1,189 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu8",
+    srcs = [
+        "source.hpp",
+        "epu8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu16",
+    srcs = [
+        "source.hpp",
+        "epu16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu32",
+    srcs = [
+        "source.hpp",
+        "epu32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu64",
+    srcs = [
+        "source.hpp",
+        "epu64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/divide/epi16.cpp
+++ b/benchmarks/divide/epi16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/divide/epi32.cpp
+++ b/benchmarks/divide/epi32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/divide/epi64.cpp
+++ b/benchmarks/divide/epi64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/divide/epi8.cpp
+++ b/benchmarks/divide/epi8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/divide/epu16.cpp
+++ b/benchmarks/divide/epu16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/divide/epu32.cpp
+++ b/benchmarks/divide/epu32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/divide/epu64.cpp
+++ b/benchmarks/divide/epu64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/divide/epu8.cpp
+++ b/benchmarks/divide/epu8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/divide/pd.cpp
+++ b/benchmarks/divide/pd.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/divide/ps.cpp
+++ b/benchmarks/divide/ps.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/divide/source.hpp
+++ b/benchmarks/divide/source.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 1e8;
+constexpr size_t RANGE_MULTIPLIER = 10;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    const auto in1 = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+    const auto in2 = md::full<T, md::dims<1>>(2, md::dims<1>{set_num});
+    auto out = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
+
+    for (auto _ : state) {
+        md::divide(in1, in2, out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/expand_dims/BUILD.bazel
+++ b/benchmarks/expand_dims/BUILD.bazel
@@ -1,0 +1,189 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu8",
+    srcs = [
+        "source.hpp",
+        "epu8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu16",
+    srcs = [
+        "source.hpp",
+        "epu16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu32",
+    srcs = [
+        "source.hpp",
+        "epu32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu64",
+    srcs = [
+        "source.hpp",
+        "epu64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/expand_dims/epi16.cpp
+++ b/benchmarks/expand_dims/epi16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/expand_dims/epi32.cpp
+++ b/benchmarks/expand_dims/epi32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/expand_dims/epi64.cpp
+++ b/benchmarks/expand_dims/epi64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/expand_dims/epi8.cpp
+++ b/benchmarks/expand_dims/epi8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/expand_dims/epu16.cpp
+++ b/benchmarks/expand_dims/epu16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/expand_dims/epu32.cpp
+++ b/benchmarks/expand_dims/epu32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/expand_dims/epu64.cpp
+++ b/benchmarks/expand_dims/epu64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/expand_dims/epu8.cpp
+++ b/benchmarks/expand_dims/epu8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/expand_dims/pd.cpp
+++ b/benchmarks/expand_dims/pd.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/expand_dims/ps.cpp
+++ b/benchmarks/expand_dims/ps.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/expand_dims/source.hpp
+++ b/benchmarks/expand_dims/source.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 1e8;
+constexpr size_t RANGE_MULTIPLIER = 10;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    const auto in = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+
+    for (auto _ : state) {
+        const auto out = md::expand_dims<-1>(in);
+        benchmark::DoNotOptimize(out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/fill/BUILD.bazel
+++ b/benchmarks/fill/BUILD.bazel
@@ -1,0 +1,189 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu8",
+    srcs = [
+        "source.hpp",
+        "epu8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu16",
+    srcs = [
+        "source.hpp",
+        "epu16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu32",
+    srcs = [
+        "source.hpp",
+        "epu32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu64",
+    srcs = [
+        "source.hpp",
+        "epu64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/fill/epi16.cpp
+++ b/benchmarks/fill/epi16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/fill/epi32.cpp
+++ b/benchmarks/fill/epi32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/fill/epi64.cpp
+++ b/benchmarks/fill/epi64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/fill/epi8.cpp
+++ b/benchmarks/fill/epi8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/fill/epu16.cpp
+++ b/benchmarks/fill/epu16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/fill/epu32.cpp
+++ b/benchmarks/fill/epu32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/fill/epu64.cpp
+++ b/benchmarks/fill/epu64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/fill/epu8.cpp
+++ b/benchmarks/fill/epu8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/fill/pd.cpp
+++ b/benchmarks/fill/pd.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/fill/ps.cpp
+++ b/benchmarks/fill/ps.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/fill/source.hpp
+++ b/benchmarks/fill/source.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 1e8;
+constexpr size_t RANGE_MULTIPLIER = 10;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    auto in = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
+
+    for (auto _ : state) {
+        md::fill(in, 1);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/full/BUILD.bazel
+++ b/benchmarks/full/BUILD.bazel
@@ -1,0 +1,189 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu8",
+    srcs = [
+        "source.hpp",
+        "epu8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu16",
+    srcs = [
+        "source.hpp",
+        "epu16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu32",
+    srcs = [
+        "source.hpp",
+        "epu32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu64",
+    srcs = [
+        "source.hpp",
+        "epu64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/full/epi16.cpp
+++ b/benchmarks/full/epi16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/full/epi32.cpp
+++ b/benchmarks/full/epi32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/full/epi64.cpp
+++ b/benchmarks/full/epi64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/full/epi8.cpp
+++ b/benchmarks/full/epi8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/full/epu16.cpp
+++ b/benchmarks/full/epu16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/full/epu32.cpp
+++ b/benchmarks/full/epu32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/full/epu64.cpp
+++ b/benchmarks/full/epu64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/full/epu8.cpp
+++ b/benchmarks/full/epu8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/full/pd.cpp
+++ b/benchmarks/full/pd.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/full/ps.cpp
+++ b/benchmarks/full/ps.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/full/source.hpp
+++ b/benchmarks/full/source.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 1e8;
+constexpr size_t RANGE_MULTIPLIER = 10;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    for (auto _ : state) {
+        const auto out = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+        benchmark::DoNotOptimize(out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/isclose/BUILD.bazel
+++ b/benchmarks/isclose/BUILD.bazel
@@ -1,0 +1,113 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/isclose/epi16.cpp
+++ b/benchmarks/isclose/epi16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/isclose/epi32.cpp
+++ b/benchmarks/isclose/epi32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/isclose/epi64.cpp
+++ b/benchmarks/isclose/epi64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/isclose/epi8.cpp
+++ b/benchmarks/isclose/epi8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/isclose/pd.cpp
+++ b/benchmarks/isclose/pd.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/isclose/ps.cpp
+++ b/benchmarks/isclose/ps.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/isclose/source.hpp
+++ b/benchmarks/isclose/source.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 1e8;
+constexpr size_t RANGE_MULTIPLIER = 10;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    const auto in1 = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+    const auto in2 = md::full<T, md::dims<1>>(2, md::dims<1>{set_num});
+    auto out = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
+
+    for (auto _ : state) {
+        md::isclose(in1, in2, out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/linalg/inv/BUILD.bazel
+++ b/benchmarks/linalg/inv/BUILD.bazel
@@ -1,0 +1,189 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu8",
+    srcs = [
+        "source.hpp",
+        "epu8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu16",
+    srcs = [
+        "source.hpp",
+        "epu16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu32",
+    srcs = [
+        "source.hpp",
+        "epu32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu64",
+    srcs = [
+        "source.hpp",
+        "epu64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/linalg/inv/epi16.cpp
+++ b/benchmarks/linalg/inv/epi16.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/inv/epi32.cpp
+++ b/benchmarks/linalg/inv/epi32.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/inv/epi64.cpp
+++ b/benchmarks/linalg/inv/epi64.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/inv/epi8.cpp
+++ b/benchmarks/linalg/inv/epi8.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/inv/epu16.cpp
+++ b/benchmarks/linalg/inv/epu16.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/inv/epu32.cpp
+++ b/benchmarks/linalg/inv/epu32.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/inv/epu64.cpp
+++ b/benchmarks/linalg/inv/epu64.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/inv/epu8.cpp
+++ b/benchmarks/linalg/inv/epu8.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/inv/pd.cpp
+++ b/benchmarks/linalg/inv/pd.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/inv/ps.cpp
+++ b/benchmarks/linalg/inv/ps.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/inv/source.hpp
+++ b/benchmarks/linalg/inv/source.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 10;
+constexpr size_t RANGE_INCREMENT = 1;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    const auto in = md::full<T, md::dims<2>>(1, md::dims<2>{set_num, set_num});
+    auto out = md::mdarray<T, md::dims<2>>{md::dims<2>{set_num, set_num}};
+
+    for (auto _ : state) {
+        md::linalg::inv(in, out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/linalg/matmul/BUILD.bazel
+++ b/benchmarks/linalg/matmul/BUILD.bazel
@@ -1,0 +1,189 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu8",
+    srcs = [
+        "source.hpp",
+        "epu8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu16",
+    srcs = [
+        "source.hpp",
+        "epu16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu32",
+    srcs = [
+        "source.hpp",
+        "epu32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu64",
+    srcs = [
+        "source.hpp",
+        "epu64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/linalg/matmul/epi16.cpp
+++ b/benchmarks/linalg/matmul/epi16.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matmul/epi32.cpp
+++ b/benchmarks/linalg/matmul/epi32.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matmul/epi64.cpp
+++ b/benchmarks/linalg/matmul/epi64.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matmul/epi8.cpp
+++ b/benchmarks/linalg/matmul/epi8.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matmul/epu16.cpp
+++ b/benchmarks/linalg/matmul/epu16.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matmul/epu32.cpp
+++ b/benchmarks/linalg/matmul/epu32.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matmul/epu64.cpp
+++ b/benchmarks/linalg/matmul/epu64.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matmul/epu8.cpp
+++ b/benchmarks/linalg/matmul/epu8.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matmul/pd.cpp
+++ b/benchmarks/linalg/matmul/pd.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matmul/ps.cpp
+++ b/benchmarks/linalg/matmul/ps.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matmul/source.hpp
+++ b/benchmarks/linalg/matmul/source.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 10;
+constexpr size_t RANGE_INCREMENT = 1;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    const auto in1 = md::full<T, md::dims<2>>(1, md::dims<2>{set_num, set_num});
+    const auto in2 = md::full<T, md::dims<2>>(2, md::dims<2>{set_num, set_num});
+    auto out = md::mdarray<T, md::dims<2>>{md::dims<2>{set_num, set_num}};
+
+    for (auto _ : state) {
+        md::linalg::matmul(in1, in2, out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/linalg/matvec/BUILD.bazel
+++ b/benchmarks/linalg/matvec/BUILD.bazel
@@ -1,0 +1,189 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu8",
+    srcs = [
+        "source.hpp",
+        "epu8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu16",
+    srcs = [
+        "source.hpp",
+        "epu16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu32",
+    srcs = [
+        "source.hpp",
+        "epu32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu64",
+    srcs = [
+        "source.hpp",
+        "epu64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/linalg/matvec/epi16.cpp
+++ b/benchmarks/linalg/matvec/epi16.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matvec/epi32.cpp
+++ b/benchmarks/linalg/matvec/epi32.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matvec/epi64.cpp
+++ b/benchmarks/linalg/matvec/epi64.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matvec/epi8.cpp
+++ b/benchmarks/linalg/matvec/epi8.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matvec/epu16.cpp
+++ b/benchmarks/linalg/matvec/epu16.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matvec/epu32.cpp
+++ b/benchmarks/linalg/matvec/epu32.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matvec/epu64.cpp
+++ b/benchmarks/linalg/matvec/epu64.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matvec/epu8.cpp
+++ b/benchmarks/linalg/matvec/epu8.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matvec/pd.cpp
+++ b/benchmarks/linalg/matvec/pd.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matvec/ps.cpp
+++ b/benchmarks/linalg/matvec/ps.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/matvec/source.hpp
+++ b/benchmarks/linalg/matvec/source.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 10;
+constexpr size_t RANGE_INCREMENT = 1;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    const auto in1 = md::full<T, md::dims<2>>(1, md::dims<2>{set_num, set_num});
+    const auto in2 = md::full<T, md::dims<1>>(2, md::dims<1>{set_num});
+    auto out = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
+
+    for (auto _ : state) {
+        md::linalg::matvec(in1, in2, out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/linalg/norm/BUILD.bazel
+++ b/benchmarks/linalg/norm/BUILD.bazel
@@ -1,0 +1,189 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu8",
+    srcs = [
+        "source.hpp",
+        "epu8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu16",
+    srcs = [
+        "source.hpp",
+        "epu16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu32",
+    srcs = [
+        "source.hpp",
+        "epu32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu64",
+    srcs = [
+        "source.hpp",
+        "epu64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/linalg/norm/epi16.cpp
+++ b/benchmarks/linalg/norm/epi16.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/norm/epi32.cpp
+++ b/benchmarks/linalg/norm/epi32.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/norm/epi64.cpp
+++ b/benchmarks/linalg/norm/epi64.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/norm/epi8.cpp
+++ b/benchmarks/linalg/norm/epi8.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/norm/epu16.cpp
+++ b/benchmarks/linalg/norm/epu16.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/norm/epu32.cpp
+++ b/benchmarks/linalg/norm/epu32.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/norm/epu64.cpp
+++ b/benchmarks/linalg/norm/epu64.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/norm/epu8.cpp
+++ b/benchmarks/linalg/norm/epu8.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/norm/pd.cpp
+++ b/benchmarks/linalg/norm/pd.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/norm/ps.cpp
+++ b/benchmarks/linalg/norm/ps.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/norm/source.hpp
+++ b/benchmarks/linalg/norm/source.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 10;
+constexpr size_t RANGE_INCREMENT = 1;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    const auto in = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+    T out;
+
+    for (auto _ : state) {
+        md::linalg::norm(in, out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/linalg/vecmat/BUILD.bazel
+++ b/benchmarks/linalg/vecmat/BUILD.bazel
@@ -1,0 +1,189 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu8",
+    srcs = [
+        "source.hpp",
+        "epu8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu16",
+    srcs = [
+        "source.hpp",
+        "epu16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu32",
+    srcs = [
+        "source.hpp",
+        "epu32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu64",
+    srcs = [
+        "source.hpp",
+        "epu64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/linalg/vecmat/epi16.cpp
+++ b/benchmarks/linalg/vecmat/epi16.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/vecmat/epi32.cpp
+++ b/benchmarks/linalg/vecmat/epi32.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/vecmat/epi64.cpp
+++ b/benchmarks/linalg/vecmat/epi64.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/vecmat/epi8.cpp
+++ b/benchmarks/linalg/vecmat/epi8.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/vecmat/epu16.cpp
+++ b/benchmarks/linalg/vecmat/epu16.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/vecmat/epu32.cpp
+++ b/benchmarks/linalg/vecmat/epu32.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/vecmat/epu64.cpp
+++ b/benchmarks/linalg/vecmat/epu64.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/vecmat/epu8.cpp
+++ b/benchmarks/linalg/vecmat/epu8.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/vecmat/pd.cpp
+++ b/benchmarks/linalg/vecmat/pd.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/vecmat/ps.cpp
+++ b/benchmarks/linalg/vecmat/ps.cpp
@@ -1,0 +1,12 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->DenseRange(RANGE_START, RANGE_END, RANGE_INCREMENT)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/linalg/vecmat/source.hpp
+++ b/benchmarks/linalg/vecmat/source.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 10;
+constexpr size_t RANGE_INCREMENT = 1;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    const auto in1 = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+    const auto in2 = md::full<T, md::dims<2>>(2, md::dims<2>{set_num, set_num});
+    auto out = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
+
+    for (auto _ : state) {
+        md::linalg::vecmat(in1, in2, out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/multiply/BUILD.bazel
+++ b/benchmarks/multiply/BUILD.bazel
@@ -1,0 +1,189 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu8",
+    srcs = [
+        "source.hpp",
+        "epu8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu16",
+    srcs = [
+        "source.hpp",
+        "epu16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu32",
+    srcs = [
+        "source.hpp",
+        "epu32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu64",
+    srcs = [
+        "source.hpp",
+        "epu64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/multiply/epi16.cpp
+++ b/benchmarks/multiply/epi16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/multiply/epi32.cpp
+++ b/benchmarks/multiply/epi32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/multiply/epi64.cpp
+++ b/benchmarks/multiply/epi64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/multiply/epi8.cpp
+++ b/benchmarks/multiply/epi8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/multiply/epu16.cpp
+++ b/benchmarks/multiply/epu16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/multiply/epu32.cpp
+++ b/benchmarks/multiply/epu32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/multiply/epu64.cpp
+++ b/benchmarks/multiply/epu64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/multiply/epu8.cpp
+++ b/benchmarks/multiply/epu8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/multiply/pd.cpp
+++ b/benchmarks/multiply/pd.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/multiply/ps.cpp
+++ b/benchmarks/multiply/ps.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/multiply/source.hpp
+++ b/benchmarks/multiply/source.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 1e8;
+constexpr size_t RANGE_MULTIPLIER = 10;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    const auto in1 = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+    const auto in2 = md::full<T, md::dims<1>>(2, md::dims<1>{set_num});
+    auto out = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
+
+    for (auto _ : state) {
+        md::multiply(in1, in2, out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/negative/BUILD.bazel
+++ b/benchmarks/negative/BUILD.bazel
@@ -1,0 +1,189 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu8",
+    srcs = [
+        "source.hpp",
+        "epu8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu16",
+    srcs = [
+        "source.hpp",
+        "epu16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu32",
+    srcs = [
+        "source.hpp",
+        "epu32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu64",
+    srcs = [
+        "source.hpp",
+        "epu64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/negative/epi16.cpp
+++ b/benchmarks/negative/epi16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/negative/epi32.cpp
+++ b/benchmarks/negative/epi32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/negative/epi64.cpp
+++ b/benchmarks/negative/epi64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/negative/epi8.cpp
+++ b/benchmarks/negative/epi8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/negative/epu16.cpp
+++ b/benchmarks/negative/epu16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/negative/epu32.cpp
+++ b/benchmarks/negative/epu32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/negative/epu64.cpp
+++ b/benchmarks/negative/epu64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/negative/epu8.cpp
+++ b/benchmarks/negative/epu8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/negative/pd.cpp
+++ b/benchmarks/negative/pd.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/negative/ps.cpp
+++ b/benchmarks/negative/ps.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/negative/source.hpp
+++ b/benchmarks/negative/source.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 1e8;
+constexpr size_t RANGE_MULTIPLIER = 10;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    const auto in = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+    auto out = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
+
+    for (auto _ : state) {
+        md::negative(in, out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/random/rand/BUILD.bazel
+++ b/benchmarks/random/rand/BUILD.bazel
@@ -1,0 +1,37 @@
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/random/rand/pd.cpp
+++ b/benchmarks/random/rand/pd.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/random/rand/ps.cpp
+++ b/benchmarks/random/rand/ps.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/random/rand/source.hpp
+++ b/benchmarks/random/rand/source.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 1e8;
+constexpr size_t RANGE_MULTIPLIER = 10;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    auto in = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
+
+    for (auto _ : state) {
+        md::random::rand(in);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/benchmarks/subtract/BUILD.bazel
+++ b/benchmarks/subtract/BUILD.bazel
@@ -1,0 +1,189 @@
+cc_binary(
+    name = "epi8",
+    srcs = [
+        "source.hpp",
+        "epi8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi16",
+    srcs = [
+        "source.hpp",
+        "epi16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi32",
+    srcs = [
+        "source.hpp",
+        "epi32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epi64",
+    srcs = [
+        "source.hpp",
+        "epi64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu8",
+    srcs = [
+        "source.hpp",
+        "epu8.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu16",
+    srcs = [
+        "source.hpp",
+        "epu16.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu32",
+    srcs = [
+        "source.hpp",
+        "epu32.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "epu64",
+    srcs = [
+        "source.hpp",
+        "epu64.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "ps",
+    srcs = [
+        "source.hpp",
+        "ps.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)
+
+cc_binary(
+    name = "pd",
+    srcs = [
+        "source.hpp",
+        "pd.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@com_google_benchmark//:benchmark",
+        "//:ctmd",
+    ],
+)

--- a/benchmarks/subtract/epi16.cpp
+++ b/benchmarks/subtract/epi16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/subtract/epi32.cpp
+++ b/benchmarks/subtract/epi32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/subtract/epi64.cpp
+++ b/benchmarks/subtract/epi64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/subtract/epi8.cpp
+++ b/benchmarks/subtract/epi8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = int8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/subtract/epu16.cpp
+++ b/benchmarks/subtract/epu16.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint16_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/subtract/epu32.cpp
+++ b/benchmarks/subtract/epu32.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint32_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/subtract/epu64.cpp
+++ b/benchmarks/subtract/epu64.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint64_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/subtract/epu8.cpp
+++ b/benchmarks/subtract/epu8.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = uint8_t;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/subtract/pd.cpp
+++ b/benchmarks/subtract/pd.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = double;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/subtract/ps.cpp
+++ b/benchmarks/subtract/ps.cpp
@@ -1,0 +1,13 @@
+#include "source.hpp"
+
+using TARGET_TYPE = float;
+
+void bm(benchmark::State &state) { test<TARGET_TYPE>(state); }
+
+BENCHMARK(bm)
+    ->RangeMultiplier(RANGE_MULTIPLIER)
+    ->Range(RANGE_START, RANGE_END)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity(benchmark::oN);
+
+BENCHMARK_MAIN();

--- a/benchmarks/subtract/source.hpp
+++ b/benchmarks/subtract/source.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+constexpr size_t RANGE_START = 1;
+constexpr size_t RANGE_END = 1e8;
+constexpr size_t RANGE_MULTIPLIER = 10;
+
+template <typename T> inline void test(benchmark::State &state) noexcept {
+    const size_t set_num = state.range(0);
+
+    const auto in1 = md::full<T, md::dims<1>>(1, md::dims<1>{set_num});
+    const auto in2 = md::full<T, md::dims<1>>(2, md::dims<1>{set_num});
+    auto out = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
+
+    for (auto _ : state) {
+        md::subtract(in1, in2, out);
+    }
+
+    state.SetComplexityN(state.range(0));
+}

--- a/ctmd/ctmd_add.hpp
+++ b/ctmd/ctmd_add.hpp
@@ -17,7 +17,6 @@ inline constexpr void add_impl(const in1_t &in1, const in2_t &in2,
 template <typename in1_t, typename in2_t, typename out_t>
 inline constexpr void add(const in1_t &in1, const in2_t &in2, out_t &out,
                           const MPMode mpmode = MPMode::NONE) noexcept {
-    // TOCO: check under non-const is faster
     auto rin1 = core::to_mdspan(in1);
     auto rin2 = core::to_mdspan(in2);
     auto rout = core::to_mdspan(out);

--- a/ctmd/ctmd_clip.hpp
+++ b/ctmd/ctmd_clip.hpp
@@ -19,10 +19,10 @@ template <typename in_t, typename min_t, typename max_t, typename out_t>
 inline constexpr void clip(const in_t &in, const min_t &min, const max_t &max,
                            out_t &out,
                            const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(in);
-    const auto rmin = core::to_mdspan(min);
-    const auto rmax = core::to_mdspan(max);
-    const auto rout = core::to_mdspan(out);
+    auto rin = core::to_mdspan(in);
+    auto rmin = core::to_mdspan(min);
+    auto rmax = core::to_mdspan(max);
+    auto rout = core::to_mdspan(out);
 
     constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
     constexpr auto urmin_exts = extents<typename decltype(rmin)::index_type>{};

--- a/ctmd/ctmd_copy.hpp
+++ b/ctmd/ctmd_copy.hpp
@@ -16,8 +16,8 @@ inline constexpr void copy_impl(const in_t &in, const out_t &out) noexcept {
 template <typename in_t, typename out_t>
 inline constexpr void copy(const in_t &in, out_t &out,
                            const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(in);
-    const auto rout = core::to_mdspan(out);
+    auto rin = core::to_mdspan(in);
+    auto rout = core::to_mdspan(out);
 
     constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
     constexpr auto urout_exts = extents<typename decltype(rout)::index_type>{};
@@ -31,7 +31,7 @@ inline constexpr void copy(const in_t &in, out_t &out,
 template <typename in_t>
 [[nodiscard]] inline constexpr auto
 copy(const in_t &in, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(in);
+    auto rin = core::to_mdspan(in);
 
     constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
     constexpr auto urout_exts = extents<typename decltype(rin)::index_type>{};

--- a/ctmd/ctmd_divide.hpp
+++ b/ctmd/ctmd_divide.hpp
@@ -17,9 +17,9 @@ inline constexpr void divide_impl(const in1_t &in1, const in2_t &in2,
 template <typename in1_t, typename in2_t, typename out_t>
 inline constexpr void divide(const in1_t &in1, const in2_t &in2, out_t &out,
                              const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(in1);
-    const auto rin2 = core::to_mdspan(in2);
-    const auto rout = core::to_mdspan(out);
+    auto rin1 = core::to_mdspan(in1);
+    auto rin2 = core::to_mdspan(in2);
+    auto rout = core::to_mdspan(out);
 
     constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
     constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
@@ -36,8 +36,8 @@ template <typename in1_t, typename in2_t>
 [[nodiscard]] inline constexpr auto
 divide(const in1_t &in1, const in2_t &in2,
        const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(in1);
-    const auto rin2 = core::to_mdspan(in2);
+    auto rin1 = core::to_mdspan(in1);
+    auto rin2 = core::to_mdspan(in2);
 
     constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
     constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};

--- a/ctmd/ctmd_fill.hpp
+++ b/ctmd/ctmd_fill.hpp
@@ -16,7 +16,7 @@ inline constexpr void fill_impl(const in_t &in, const val_t &val) noexcept {
 template <typename in_t, arithmetic_c val_t>
 inline constexpr void fill(in_t &in, const val_t &val,
                            const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(in);
+    auto rin = core::to_mdspan(in);
 
     constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
 

--- a/ctmd/ctmd_isclose.hpp
+++ b/ctmd/ctmd_isclose.hpp
@@ -16,15 +16,15 @@ inline constexpr void isclose_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename in1_t, typename in2_t, typename out_t, arithmetic_c rtol_t,
-          arithmetic_c atol_t>
+template <typename in1_t, typename in2_t, typename out_t,
+          arithmetic_c rtol_t = double, arithmetic_c atol_t = double>
 inline constexpr void isclose(const in1_t &in1, const in2_t &in2, out_t &out,
                               const rtol_t &rtol = 1e-05,
                               const atol_t &atol = 1e-08,
                               const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(in1);
-    const auto rin2 = core::to_mdspan(in2);
-    const auto rout = core::to_mdspan(out);
+    auto rin1 = core::to_mdspan(in1);
+    auto rin2 = core::to_mdspan(in2);
+    auto rout = core::to_mdspan(out);
 
     constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
     constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
@@ -40,14 +40,14 @@ inline constexpr void isclose(const in1_t &in1, const in2_t &in2, out_t &out,
         mpmode);
 }
 
-template <typename in1_t, typename in2_t, arithmetic_c rtol_t,
-          arithmetic_c atol_t>
+template <typename in1_t, typename in2_t, arithmetic_c rtol_t = double,
+          arithmetic_c atol_t = double>
 [[nodiscard]] inline constexpr auto
 isclose(const in1_t &in1, const in2_t &in2, const rtol_t &rtol = 1e-05,
         const atol_t &atol = 1e-08,
         const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(in1);
-    const auto rin2 = core::to_mdspan(in2);
+    auto rin1 = core::to_mdspan(in1);
+    auto rin2 = core::to_mdspan(in2);
 
     constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
     constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};

--- a/ctmd/ctmd_multiply.hpp
+++ b/ctmd/ctmd_multiply.hpp
@@ -17,9 +17,9 @@ inline constexpr void multiply_impl(const in1_t &in1, const in2_t &in2,
 template <typename in1_t, typename in2_t, typename out_t>
 inline constexpr void multiply(const in1_t &in1, const in2_t &in2, out_t &out,
                                const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(in1);
-    const auto rin2 = core::to_mdspan(in2);
-    const auto rout = core::to_mdspan(out);
+    auto rin1 = core::to_mdspan(in1);
+    auto rin2 = core::to_mdspan(in2);
+    auto rout = core::to_mdspan(out);
 
     constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
     constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
@@ -36,8 +36,8 @@ template <typename in1_t, typename in2_t>
 [[nodiscard]] inline constexpr auto
 multiply(const in1_t &in1, const in2_t &in2,
          const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(in1);
-    const auto rin2 = core::to_mdspan(in2);
+    auto rin1 = core::to_mdspan(in1);
+    auto rin2 = core::to_mdspan(in2);
 
     constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
     constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};

--- a/ctmd/ctmd_negative.hpp
+++ b/ctmd/ctmd_negative.hpp
@@ -16,8 +16,8 @@ inline constexpr void negative_impl(const in_t &in, const out_t &out) noexcept {
 template <typename in_t, typename out_t>
 inline constexpr void negative(const in_t &in, out_t &out,
                                const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(in);
-    const auto rout = core::to_mdspan(out);
+    auto rin = core::to_mdspan(in);
+    auto rout = core::to_mdspan(out);
 
     constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
     constexpr auto urout_exts = extents<typename decltype(rout)::index_type>{};
@@ -31,7 +31,7 @@ inline constexpr void negative(const in_t &in, out_t &out,
 template <typename in_t>
 [[nodiscard]] inline constexpr auto
 negative(const in_t &in, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(in);
+    auto rin = core::to_mdspan(in);
 
     constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
     constexpr auto urout_exts = extents<typename decltype(rin)::index_type>{};

--- a/ctmd/ctmd_subtract.hpp
+++ b/ctmd/ctmd_subtract.hpp
@@ -17,9 +17,9 @@ inline constexpr void subtract_impl(const in1_t &in1, const in2_t &in2,
 template <typename in1_t, typename in2_t, typename out_t>
 inline constexpr void subtract(const in1_t &in1, const in2_t &in2, out_t &out,
                                const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(in1);
-    const auto rin2 = core::to_mdspan(in2);
-    const auto rout = core::to_mdspan(out);
+    auto rin1 = core::to_mdspan(in1);
+    auto rin2 = core::to_mdspan(in2);
+    auto rout = core::to_mdspan(out);
 
     constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
     constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
@@ -36,8 +36,8 @@ template <typename in1_t, typename in2_t>
 [[nodiscard]] inline constexpr auto
 subtract(const in1_t &in1, const in2_t &in2,
          const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(in1);
-    const auto rin2 = core::to_mdspan(in2);
+    auto rin1 = core::to_mdspan(in1);
+    auto rin2 = core::to_mdspan(in2);
 
     constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
     constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};

--- a/ctmd/linalg/ctmd_linalg_inv.hpp
+++ b/ctmd/linalg/ctmd_linalg_inv.hpp
@@ -76,8 +76,8 @@ template <md_c in_t, md_c out_t>
     requires(in_t::rank() >= 2 && out_t::rank() >= 2)
 inline constexpr void inv(const in_t &in, out_t &out,
                           const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(in);
-    const auto rout = core::to_mdspan(out);
+    auto rin = core::to_mdspan(in);
+    auto rout = core::to_mdspan(out);
 
     const auto urin_exts = core::slice_from_last<2>(rin.extents());
     const auto urout_exts = core::slice_from_last<2>(rout.extents());
@@ -92,7 +92,7 @@ template <md_c in_t>
     requires(in_t::rank() >= 2)
 [[nodiscard]] inline constexpr auto
 inv(const in_t &in, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(in);
+    auto rin = core::to_mdspan(in);
 
     const auto urin_exts = core::slice_from_last<2>(rin.extents());
     const auto urout_exts = urin_exts;

--- a/ctmd/linalg/ctmd_linalg_matmul.hpp
+++ b/ctmd/linalg/ctmd_linalg_matmul.hpp
@@ -62,9 +62,9 @@ template <md_c in1_t, md_c in2_t, md_c out_t>
     requires(in1_t::rank() >= 2 && in2_t::rank() >= 2 && out_t::rank() >= 2)
 inline constexpr void matmul(const in1_t &in1, const in2_t &in2, out_t &out,
                              const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(in1);
-    const auto rin2 = core::to_mdspan(in2);
-    const auto rout = core::to_mdspan(out);
+    auto rin1 = core::to_mdspan(in1);
+    auto rin2 = core::to_mdspan(in2);
+    auto rout = core::to_mdspan(out);
 
     const auto urin1_exts = core::slice_from_last<2>(rin1.extents());
     const auto urin2_exts = core::slice_from_last<2>(rin2.extents());
@@ -82,8 +82,8 @@ template <md_c in1_t, md_c in2_t>
 [[nodiscard]] inline constexpr auto
 matmul(const in1_t &in1, const in2_t &in2,
        const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(in1);
-    const auto rin2 = core::to_mdspan(in2);
+    auto rin1 = core::to_mdspan(in1);
+    auto rin2 = core::to_mdspan(in2);
 
     const auto urin1_exts = core::slice_from_last<2>(rin1.extents());
     const auto urin2_exts = core::slice_from_last<2>(rin2.extents());

--- a/ctmd/linalg/ctmd_linalg_matvec.hpp
+++ b/ctmd/linalg/ctmd_linalg_matvec.hpp
@@ -41,6 +41,7 @@ inline constexpr void matvec_impl(const in1_t &in1, const in2_t &in2,
         matvec_naive(in1, in2, out);
 
     } else {
+        // TODO: optimize condition
         if (std::is_constant_evaluated() || out.extent(0) <= 8) [[likely]] {
             matvec_naive(in1, in2, out);
 
@@ -59,12 +60,12 @@ template <md_c in1_t, md_c in2_t, md_c out_t>
     requires(in1_t::rank() >= 2 && in2_t::rank() >= 1 && out_t::rank() >= 1)
 inline constexpr void matvec(const in1_t &in1, const in2_t &in2, out_t &out,
                              const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(in1);
-    const auto rin2 = core::to_mdspan(in2);
-    const auto rout = core::to_mdspan(out);
+    auto rin1 = core::to_mdspan(in1);
+    auto rin2 = core::to_mdspan(in2);
+    auto rout = core::to_mdspan(out);
 
     const auto urin1_exts = core::slice_from_last<2>(rin1.extents());
-    const auto urin2_exts = core::slice_from_last<2>(rin2.extents());
+    const auto urin2_exts = core::slice_from_last<1>(rin2.extents());
     const auto urout_exts = core::slice_from_last<1>(rout.extents());
 
     core::batch([](const auto &in1, const auto &in2,
@@ -79,8 +80,8 @@ template <md_c in1_t, md_c in2_t>
 [[nodiscard]] inline constexpr auto
 matvec(const in1_t &in1, const in2_t &in2,
        const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(in1);
-    const auto rin2 = core::to_mdspan(in2);
+    auto rin1 = core::to_mdspan(in1);
+    auto rin2 = core::to_mdspan(in2);
 
     const auto urin1_exts = core::slice_from_last<2>(rin1.extents());
     const auto urin2_exts = core::slice_from_last<1>(rin2.extents());

--- a/ctmd/linalg/ctmd_linalg_norm.hpp
+++ b/ctmd/linalg/ctmd_linalg_norm.hpp
@@ -22,8 +22,8 @@ template <md_c in_t, typename out_t>
     requires(in_t::rank() >= 1)
 inline constexpr void norm(const in_t &in, out_t &out,
                            const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(in);
-    const auto rout = core::to_mdspan(out);
+    auto rin = core::to_mdspan(in);
+    auto rout = core::to_mdspan(out);
 
     const auto urin_exts = core::slice_from_last<1>(rin.extents());
     constexpr auto urout_exts = extents<typename decltype(rout)::index_type>{};
@@ -38,7 +38,7 @@ template <md_c in_t>
     requires(in_t::rank() >= 1)
 [[nodiscard]] inline constexpr auto
 norm(const in_t &in, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(in);
+    auto rin = core::to_mdspan(in);
 
     const auto urin_exts = core::slice_from_last<1>(rin.extents());
     constexpr auto urout_exts = extents<typename decltype(rin)::index_type>{};

--- a/ctmd/linalg/ctmd_linalg_vecmat.hpp
+++ b/ctmd/linalg/ctmd_linalg_vecmat.hpp
@@ -41,6 +41,7 @@ inline constexpr void vecmat_impl(const in1_t &in1, const in2_t &in2,
         vecmat_naive(in1, in2, out);
 
     } else {
+        // TODO: optimize condition
         if (std::is_constant_evaluated() || out.extent(0) <= 8) [[likely]] {
             vecmat_naive(in1, in2, out);
 
@@ -59,9 +60,9 @@ template <md_c in1_t, md_c in2_t, md_c out_t>
     requires(in1_t::rank() >= 1 && in2_t::rank() >= 2 && out_t::rank() >= 1)
 inline constexpr void vecmat(const in1_t &in1, const in2_t &in2, out_t &out,
                              const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(in1);
-    const auto rin2 = core::to_mdspan(in2);
-    const auto rout = core::to_mdspan(out);
+    auto rin1 = core::to_mdspan(in1);
+    auto rin2 = core::to_mdspan(in2);
+    auto rout = core::to_mdspan(out);
 
     const auto urin1_exts = core::slice_from_last<1>(rin1.extents());
     const auto urin2_exts = core::slice_from_last<2>(rin2.extents());
@@ -79,8 +80,8 @@ template <md_c in1_t, md_c in2_t>
 [[nodiscard]] inline constexpr auto
 vecmat(const in1_t &in1, const in2_t &in2,
        const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(in1);
-    const auto rin2 = core::to_mdspan(in2);
+    auto rin1 = core::to_mdspan(in1);
+    auto rin2 = core::to_mdspan(in2);
 
     const auto urin1_exts = core::slice_from_last<1>(rin1.extents());
     const auto urin2_exts = core::slice_from_last<2>(rin2.extents());

--- a/ctmd/random/ctmd_random_rand.hpp
+++ b/ctmd/random/ctmd_random_rand.hpp
@@ -72,7 +72,7 @@ inline constexpr void rand_impl(const in_t &in) noexcept {
 template <typename in_t>
 inline constexpr void rand(in_t &in,
                            const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(in);
+    auto rin = core::to_mdspan(in);
 
     if constexpr (decltype(rin)::rank_dynamic() == 0) {
         if (std::is_constant_evaluated()) {


### PR DESCRIPTION
This pull request introduces significant refactoring and enhancements to the benchmarking codebase, focusing on improving variable naming consistency, adding new benchmark binaries, and centralizing shared logic. The changes aim to enhance code readability, maintainability, and extensibility.

### Refactoring for Consistency:
* Updated variable names in multiple `test` functions across files (`benchmarks/add/cpump/raw/source.hpp`, `benchmarks/add/cpump/source.hpp`, `benchmarks/add/gpump/raw/source.hpp`, `benchmarks/add/gpump/source.hpp`, `benchmarks/add/raw/source.hpp`, `benchmarks/add/source.hpp`) to use `in1`, `in2`, and `out` instead of `a`, `b`, and `c` for input and output vectors. This improves clarity and aligns with standard naming conventions. [[1]](diffhunk://#diff-1b1171f6e00a7e7b65ef2edf473e5770763747928b490a3113f319ddfd00cec0L12-R19) [[2]](diffhunk://#diff-c501516e2fc18bebf261530cf87151686607e15b81020d304ecc71ef04c334b2L15-R20) [[3]](diffhunk://#diff-9313781ab7c04b0025785340305b3f14a6016ceb8b18cc4647a45a1ece35248dL12-R32) [[4]](diffhunk://#diff-154229bdf68b40955f4ffded1e367b319b819528114e6ffbc311fb39880a65cdL15-R20) [[5]](diffhunk://#diff-3d801e86245cce91077993da1b837df34ce986f59174ffa49771f55a46a42001L12-R18) [[6]](diffhunk://#diff-5a651617693a0bb0e7d729263c6e0bc395ee8150bd1cd1e2bf6004ac80b35ea7L15-R20)

### Addition of New Benchmarks:
* Added multiple benchmark binaries in `benchmarks/all/BUILD.bazel` and `benchmarks/allclose/BUILD.bazel` for various data types, including `epi8`, `epi16`, `epi32`, `epi64`, `epu8`, `epu16`, `epu32`, `epu64`, `ps`, and `pd`. These binaries are configured with optimization flags and dependencies. [[1]](diffhunk://#diff-f906983e445da97caca24ef9b5dfa4c436569fe6982c0871dba1691cf7db4f9bR1-R189) [[2]](diffhunk://#diff-5190a770365fd98fa06b78f790153bcb4f0832895bd9477b27ccc0b4b338f389R1-R113)
* Implemented corresponding benchmark files (e.g., `epi8.cpp`, `epi16.cpp`, etc.) for each binary, defining benchmarks for specific data types (`int8_t`, `int16_t`, `uint8_t`, `float`, etc.) and using the shared `test` function. [[1]](diffhunk://#diff-5573e9d06d05528790d707f41224bcfa903c8cbfa1f63cc23f6dba5bfb95468fR1-R13) [[2]](diffhunk://#diff-7f77bc1fe5badf1d5436918b8fa1d0c63710d57393e77fac083cbdc90f732f1fR1-R13) [[3]](diffhunk://#diff-99c8699c5565875ed3cd4322f9b72791e71fdf7cfca1e6c6b7c80a2607a759f3R1-R13) [[4]](diffhunk://#diff-693ff2d6dec7150c3a94e842a9876a64aedff2891101e6a455d6efd739f78d60R1-R13) [[5]](diffhunk://#diff-7dfb541a6d8219f386d465e47ea66fa49c92fa49b253b9c0a20653c6e9a7513fR1-R13) [[6]](diffhunk://#diff-806e36ebaed2b723c0120c850c3966ad25e572c8367c5d35110f55fc72cb9238R1-R13) [[7]](diffhunk://#diff-bc6ba545344f936fb3c1e19ce5cbd6bfcd307e74029d955aca2a2f46a9e7c0d3R1-R13) [[8]](diffhunk://#diff-a3f79497efadef1e90a574462f09308d473cccfe41c49f914a0fb3b5a530d856R1-R13) [[9]](diffhunk://#diff-9a5667132e885cac61a5c2471fcb71bbfa230dbb0ee44922f6660d9704983cf2R1-R13) [[10]](diffhunk://#diff-f097b0f66593dad4538f6b4a9dba8dc909c91687e8bce7bc7fad9dc09369beffR1-R13)

### Centralization of Shared Logic:
* Introduced a new `source.hpp` file in `benchmarks/all/` and `benchmarks/allclose/` that centralizes shared logic for the `test` function. This includes utility functions and constants like `RANGE_START`, `RANGE_END`, and `RANGE_MULTIPLIER`, reducing redundancy across benchmarks.