### PR TITLE
add mpmode

### DIFF
--- a/ctmd/ctmd_add.hpp
+++ b/ctmd/ctmd_add.hpp
@@ -36,7 +36,6 @@ template <typename in1_t, typename in2_t>
 [[nodiscard]] inline constexpr auto
 add(const in1_t &in1, const in2_t &in2,
     const MPMode mpmode = MPMode::NONE) noexcept {
-    // TOCO: check under non-const is faster
     auto rin1 = core::to_mdspan(in1);
     auto rin2 = core::to_mdspan(in2);
 

--- a/ctmd/random/ctmd_random_rand.hpp
+++ b/ctmd/random/ctmd_random_rand.hpp
@@ -100,9 +100,10 @@ inline constexpr void rand(in_t &in,
 
 template <typename T, extents_c extents_t>
 [[nodiscard]] inline constexpr auto
-rand(const extents_t &extents = extents_t{}) noexcept {
+rand(const extents_t &extents = extents_t{},
+     const MPMode mpmode = MPMode::NONE) noexcept {
     auto out = ctmd::mdarray<T, extents_t>{extents};
-    rand(out);
+    rand(out, mpmode);
     return out;
 }
 


### PR DESCRIPTION
This pull request introduces minor improvements to the `ctmd` library by refining function signatures and enhancing consistency in handling the `MPMode` parameter. The changes focus on improving flexibility and maintaining uniformity across related functions.

### Changes to function signatures for consistency:

* [`ctmd/ctmd_add.hpp`](diffhunk://#diff-bd3b324b8e59310aa8e4dcc7aaaac891c4a394c1ee586c0ab937dd9a826fdf76L39): Removed a commented-out TODO note and retained the existing implementation for converting inputs to `mdspan`.
* [`ctmd/random/ctmd_random_rand.hpp`](diffhunk://#diff-1fdc117d57eae8778a3740616edb25672cacaf851d40cdd5dd125e656011f593L103-R106): Updated the `rand` function to include an optional `MPMode` parameter, ensuring consistency with other functions that support multi-processing modes. Adjusted the internal call to `rand` to pass the `MPMode` parameter.