### PR TITLE
Update ctmd_expand_dims.hpp

### DIFF
--- a/ctmd/ctmd_expand_dims.hpp
+++ b/ctmd/ctmd_expand_dims.hpp
@@ -5,7 +5,7 @@
 namespace ctmd {
 
 template <int64_t Axis, md_c in_t>
-[[nodiscard]] inline auto expand_dims(in_t &in) noexcept {
+[[nodiscard]] inline constexpr auto expand_dims(in_t &in) noexcept {
     constexpr size_t axis =
         static_cast<size_t>(((Axis % (in_t::rank() + 1)) + (in_t::rank() + 1)) %
                             (in_t::rank() + 1));

--- a/ctmd/ctmd_expand_dims.hpp
+++ b/ctmd/ctmd_expand_dims.hpp
@@ -4,38 +4,35 @@
 
 namespace ctmd {
 
-template <int64_t Axis, md_c in_t>
+template <int64_t Axis, typename in_t>
 [[nodiscard]] inline constexpr auto expand_dims(in_t &in) noexcept {
+    auto rin = core::to_mdspan(in);
+    using rin_t = decltype(rin);
+
+    constexpr size_t rank = rin_t::rank();
+
     constexpr size_t axis =
-        static_cast<size_t>(((Axis % (in_t::rank() + 1)) + (in_t::rank() + 1)) %
-                            (in_t::rank() + 1));
+        static_cast<size_t>(((Axis % (rank + 1)) + (rank + 1)) % (rank + 1));
 
-    const auto in_span = core::to_mdspan(in);
-    using in_span_t = decltype(in_span);
+    const auto new_extents = [&rin]<size_t... Is>(std::index_sequence<Is...>) {
+        return extents<
+            typename rin_t::index_type,
+            (Is < axis ? rin_t::static_extent(Is)
+                       : (Is == axis ? 1 : rin_t::static_extent(Is - 1)))...>{
+            (Is < axis ? rin.extent(Is)
+                       : (Is == axis ? 1 : rin.extent(Is - 1)))...};
+    }(std::make_index_sequence<rank + 1>{});
 
-    const auto new_extents =
-        [&in_span]<size_t... Is>(std::index_sequence<Is...>) {
-            return extents<
-                typename in_span_t::index_type,
-                (Is < axis
-                     ? in_span_t::static_extent(Is)
-                     : (Is == axis ? 1 : in_span_t::static_extent(Is - 1)))...>{
-                (Is < axis ? in_span.extent(Is)
-                           : (Is == axis ? 1 : in_span.extent(Is - 1)))...};
-        }(std::make_index_sequence<in_span_t::rank() + 1>{});
+    const auto new_strides = [&rin]<size_t... Is>(std::index_sequence<Is...>) {
+        return std::array<typename rin_t::size_type, rank + 1>{
+            (Is < axis ? rin.stride(Is)
+                       : (Is == axis ? 1 : rin.stride(Is - 1)))...};
+    }(std::make_index_sequence<rank + 1>{});
 
-    const auto new_strides = [&in_span]<size_t... Is>(
-                                 std::index_sequence<Is...>) {
-        return std::array<typename in_span_t::size_type, in_span_t::rank() + 1>{
-            (Is < axis ? in_span.stride(Is)
-                       : (Is == axis ? 1 : in_span.stride(Is - 1)))...};
-    }(std::make_index_sequence<in_span_t::rank() + 1>{});
-
-    return mdspan<typename in_span_t::element_type,
+    return mdspan<typename rin_t::element_type,
                   std::remove_const_t<decltype(new_extents)>, layout_stride,
-                  typename in_span_t::accessor_type>{
-        in_span.data_handle(),
-        layout_stride::mapping{new_extents, new_strides}};
+                  typename rin_t::accessor_type>{
+        rin.data_handle(), layout_stride::mapping{new_extents, new_strides}};
 }
 
 } // namespace ctmd

--- a/ctmd/ctmd_expand_dims.hpp
+++ b/ctmd/ctmd_expand_dims.hpp
@@ -11,28 +11,39 @@ template <int64_t Axis, typename in_t>
 
     constexpr size_t rank = rin_t::rank();
 
-    constexpr size_t axis =
-        static_cast<size_t>(((Axis % (rank + 1)) + (rank + 1)) % (rank + 1));
+    if constexpr (rank == 0) {
+        auto new_extents = extents<typename rin_t::index_type, 1>{1};
+        return mdspan<typename rin_t::element_type, decltype(new_extents)>{
+            rin.data_handle(), new_extents};
 
-    const auto new_extents = [&rin]<size_t... Is>(std::index_sequence<Is...>) {
-        return extents<
-            typename rin_t::index_type,
-            (Is < axis ? rin_t::static_extent(Is)
-                       : (Is == axis ? 1 : rin_t::static_extent(Is - 1)))...>{
-            (Is < axis ? rin.extent(Is)
-                       : (Is == axis ? 1 : rin.extent(Is - 1)))...};
-    }(std::make_index_sequence<rank + 1>{});
+    } else {
+        constexpr size_t axis = static_cast<size_t>(
+            ((Axis % (rank + 1)) + (rank + 1)) % (rank + 1));
 
-    const auto new_strides = [&rin]<size_t... Is>(std::index_sequence<Is...>) {
-        return std::array<typename rin_t::size_type, rank + 1>{
-            (Is < axis ? rin.stride(Is)
-                       : (Is == axis ? 1 : rin.stride(Is - 1)))...};
-    }(std::make_index_sequence<rank + 1>{});
+        const auto new_extents =
+            [&rin]<size_t... Is>(std::index_sequence<Is...>) {
+                return extents<
+                    typename rin_t::index_type,
+                    (Is < axis
+                         ? rin_t::static_extent(Is)
+                         : (Is == axis ? 1 : rin_t::static_extent(Is - 1)))...>{
+                    (Is < axis ? rin.extent(Is)
+                               : (Is == axis ? 1 : rin.extent(Is - 1)))...};
+            }(std::make_index_sequence<rank + 1>{});
 
-    return mdspan<typename rin_t::element_type,
-                  std::remove_const_t<decltype(new_extents)>, layout_stride,
-                  typename rin_t::accessor_type>{
-        rin.data_handle(), layout_stride::mapping{new_extents, new_strides}};
+        const auto new_strides =
+            [&rin]<size_t... Is>(std::index_sequence<Is...>) {
+                return std::array<typename rin_t::size_type, rank + 1>{
+                    (Is < axis ? rin.stride(Is)
+                               : (Is == axis ? 1 : rin.stride(Is - 1)))...};
+            }(std::make_index_sequence<rank + 1>{});
+
+        return mdspan<typename rin_t::element_type,
+                      std::remove_const_t<decltype(new_extents)>, layout_stride,
+                      typename rin_t::accessor_type>{
+            rin.data_handle(),
+            layout_stride::mapping{new_extents, new_strides}};
+    }
 }
 
 } // namespace ctmd

--- a/tests/expand_dims/main.cpp
+++ b/tests/expand_dims/main.cpp
@@ -4,9 +4,7 @@
 
 namespace md = ctmd;
 
-TEST(stack, expand_dims) {
-    // NOTE: mdspan does not support constexpr
-
+TEST(stack, 1) {
     using T = double;
 
     constexpr auto x = md::mdarray<T, md::extents<size_t, 2>>{
@@ -15,6 +13,20 @@ TEST(stack, expand_dims) {
 
     constexpr auto b_expect = md::mdarray<T, md::extents<size_t, 2, 1>>{
         std::array<T, 2>{1, 2}, md::extents<size_t, 2, 1>{}};
+
+    const bool array_equal = md::array_equal(b, b_expect);
+
+    ASSERT_TRUE(array_equal);
+}
+
+TEST(stack, 2) {
+    using T = double;
+
+    constexpr T x = 1;
+    const auto b = md::expand_dims<0>(x);
+
+    constexpr auto b_expect = md::mdarray<T, md::extents<size_t, 1>>{
+        std::array<T, 1>{1}, md::extents<size_t, 1>{}};
 
     const bool array_equal = md::array_equal(b, b_expect);
 

--- a/tests/random/rand/main.cpp
+++ b/tests/random/rand/main.cpp
@@ -4,22 +4,42 @@
 
 namespace md = ctmd;
 
-TEST(stack, rand) {
+TEST(stack, 1) {
     using T = double;
 
-    constexpr auto a = md::random::rand<T, md::extents<size_t, 2, 2>>();
+    constexpr auto out = md::random::rand<T, md::extents<size_t, 2, 2>>();
 
-    std::cout << md::to_string(a) << std::endl;
+    std::cout << md::to_string(out) << std::endl;
 
-    ASSERT_TRUE(!md::allclose(a, md::full<T, md::extents<size_t, 2, 2>>(0)));
+    ASSERT_TRUE(!md::allclose(out, md::full<T, md::extents<size_t, 2, 2>>(0)));
 }
 
-TEST(heap, rand) {
+TEST(stack, 2) {
     using T = double;
 
-    const auto a = md::random::rand<T, md::dims<2>>(md::dims<2>{2, 2});
+    constexpr auto out = md::random::rand<T>();
 
-    std::cout << md::to_string(a) << std::endl;
+    std::cout << md::to_string(out) << std::endl;
 
-    ASSERT_TRUE(!md::allclose(a, md::full<T, md::extents<size_t, 2, 2>>(0)));
+    ASSERT_TRUE(out != 0);
+}
+
+TEST(heap, 1) {
+    using T = double;
+
+    const auto out = md::random::rand<T, md::dims<2>>(md::dims<2>{2, 2});
+
+    std::cout << md::to_string(out) << std::endl;
+
+    ASSERT_TRUE(!md::allclose(out, md::full<T, md::extents<size_t, 2, 2>>(0)));
+}
+
+TEST(heap, 2) {
+    using T = double;
+
+    const auto out = md::random::rand<T>();
+
+    std::cout << md::to_string(out) << std::endl;
+
+    ASSERT_TRUE(out != 0);
 }


### PR DESCRIPTION
This pull request includes a small change to the `ctmd/ctmd_expand_dims.hpp` file. The change updates the `expand_dims` function to be marked as `constexpr`, allowing it to be evaluated at compile time where applicable.