### PR TITLE
Hotfix c++20

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,3 @@
-build --action_env=BAZEL_CXXOPTS="-std=c++23" --compilation_mode=opt
-run --action_env=BAZEL_CXXOPTS="-std=c++23" --compilation_mode=opt
-test --action_env=BAZEL_CXXOPTS="-std=c++23" --compilation_mode=opt
+build --action_env=BAZEL_CXXOPTS="-std=c++20" --compilation_mode=opt
+run --action_env=BAZEL_CXXOPTS="-std=c++20" --compilation_mode=opt
+test --action_env=BAZEL_CXXOPTS="-std=c++20" --compilation_mode=opt

--- a/README.md
+++ b/README.md
@@ -10,10 +10,19 @@
 - **Compile-Time Computation**: Enables compile-time operations when possible for maximum efficiency.
 - **Flexibility**: Seamlessly supports constexpr and non-constexpr contexts, diverse data types, and both static and dynamic extents.
 - **High Performance**: Optimized for fast execution, leveraging modern C++ and hardware acceleration.
-- **Modern C++ Support**: Fully compatible with C++23 and ready to adopt future features like [std::linalg](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p1673r12.html).
+- **Modern C++ Support**: Fully compatible with C++23 and ready to adopt future features like [std::linalg](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p1673r12.html) in C++26.
 
 ### Important Notes
-- A single vector has 1D extents, while a single matrix has 2D extents (following the rules of [std::linalg](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p1673r12.html)).
+- C++ Version Compatibility:
+  - CTMD requires **C++20** or higher for full functionality.
+  - [std::mdspan](https://en.cppreference.com/w/cpp/container/mdspan) (C++23), [std::mdarray](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1684r2.html) (C++26), [std::submdspan](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2630r4.html) (C++26) are sourced from the [Reference mdspan implementation](https://github.com/kokkos/mdspan).
+- Extent Conventions:
+  - **Scalar (0D mdspan)**: Data stored as an **arithmetic type** (e.g., int, float, double).
+  - **Vector (1D mdspan)**: Data stored as a **1D mdarray**.
+  - **Matrix (2D mdspan)**: Data stored as a **2D mdarray**.
+- Acceleration:
+  - Using **Eigen**: Define the macro "USE_EIGEN" during build.
+  - Using **OpenMP**: Add the -fopenmp flag during compilation and link with the OpenMP library (-lgomp).
 
 ## Installation
 CTMD is a header-only library, so you can start using it by simply including [ctmd/ctmd.hpp](ctmd/ctmd.hpp) in your project.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -86,7 +86,7 @@ cc_library(
     hdrs = glob(["include/**/*"]),
     srcs = [],
     includes = ["include/"],
-    defines = ["MDSPAN_USE_BRACKET_OPERATOR=1"],
+    defines = ["MDSPAN_USE_BRACKET_OPERATOR=0"], # NOTE: For C++20 compatibility
     visibility = ["//visibility:public"],
 )
 """

--- a/ctmd/ctmd_add.hpp
+++ b/ctmd/ctmd_add.hpp
@@ -9,7 +9,7 @@ template <mdspan_c in1_t, mdspan_c in2_t, mdspan_c out_t>
     requires(in1_t::rank() == 0 && in2_t::rank() == 0 && out_t::rank() == 0)
 inline constexpr void add_impl(const in1_t &in1, const in2_t &in2,
                                const out_t &out) noexcept {
-    out[] = in1[] + in2[];
+    out() = in1() + in2();
 }
 
 } // namespace detail

--- a/ctmd/ctmd_all.hpp
+++ b/ctmd/ctmd_all.hpp
@@ -14,7 +14,7 @@ template <typename in_t>
 
     } else {
         if constexpr (rin_t::rank() == 0) {
-            return static_cast<bool>(rin[]);
+            return static_cast<bool>(rin());
 
         } else {
             for (typename rin_t::size_type i = 0; i < rin.extent(0); i++) {

--- a/ctmd/ctmd_array_equal.hpp
+++ b/ctmd/ctmd_array_equal.hpp
@@ -23,7 +23,7 @@ template <typename in1_t, typename in2_t>
     }
 
     if constexpr (rint1_t::rank() == 0) {
-        return rin1[] == rin2[];
+        return rin1() == rin2();
 
     } else {
         for (typename rint1_t::size_type i = 0; i < rin1.extent(0); i++) {

--- a/ctmd/ctmd_clip.hpp
+++ b/ctmd/ctmd_clip.hpp
@@ -10,8 +10,8 @@ template <mdspan_c in_t, mdspan_c min_t, mdspan_c max_t, mdspan_c out_t>
              out_t::rank() == 0)
 inline constexpr void clip_impl(const in_t &in, const min_t &min,
                                 const max_t &max, const out_t &out) noexcept {
-    out[] = std::clamp(in[], static_cast<decltype(in[])>(min[]),
-                       static_cast<decltype(in[])>(max[]));
+    out() = std::clamp(in(), static_cast<decltype(in())>(min()),
+                       static_cast<decltype(in())>(max()));
 }
 
 } // namespace detail

--- a/ctmd/ctmd_copy.hpp
+++ b/ctmd/ctmd_copy.hpp
@@ -8,7 +8,7 @@ namespace detail {
 template <mdspan_c in_t, mdspan_c out_t>
     requires(in_t::rank() == 0 && out_t::rank() == 0)
 inline constexpr void copy_impl(const in_t &in, const out_t &out) noexcept {
-    out[] = in[];
+    out() = in();
 }
 
 } // namespace detail

--- a/ctmd/ctmd_divide.hpp
+++ b/ctmd/ctmd_divide.hpp
@@ -9,7 +9,7 @@ template <mdspan_c in1_t, mdspan_c in2_t, mdspan_c out_t>
     requires(in1_t::rank() == 0 && in2_t::rank() == 0 && out_t::rank() == 0)
 inline constexpr void divide_impl(const in1_t &in1, const in2_t &in2,
                                   const out_t &out) noexcept {
-    out[] = in1[] / in2[];
+    out() = in1() / in2();
 }
 
 } // namespace detail

--- a/ctmd/ctmd_equal.hpp
+++ b/ctmd/ctmd_equal.hpp
@@ -9,7 +9,7 @@ template <mdspan_c in1_t, mdspan_c in2_t, mdspan_c out_t>
     requires(in1_t::rank() == 0 && in2_t::rank() == 0 && out_t::rank() == 0)
 inline constexpr void equal_impl(const in1_t &in1, const in2_t &in2,
                                  const out_t &out) noexcept {
-    out[] = (in1[] == in2[]);
+    out() = (in1() == in2());
 }
 
 } // namespace detail

--- a/ctmd/ctmd_fill.hpp
+++ b/ctmd/ctmd_fill.hpp
@@ -8,7 +8,7 @@ namespace detail {
 template <mdspan_c in_t, arithmetic_c val_t>
     requires(in_t::rank() == 0)
 inline constexpr void fill_impl(const in_t &in, const val_t &val) noexcept {
-    in[] = val;
+    in() = val;
 }
 
 } // namespace detail

--- a/ctmd/ctmd_isclose.hpp
+++ b/ctmd/ctmd_isclose.hpp
@@ -11,7 +11,7 @@ template <mdspan_c in1_t, mdspan_c in2_t, mdspan_c out_t,
 inline constexpr void isclose_impl(const in1_t &in1, const in2_t &in2,
                                    const out_t &out, const rtol_t &rtol,
                                    const atol_t &atol) noexcept {
-    out[] = std::abs(in1[] - in2[]) <= (atol + rtol * std::abs(in2[]));
+    out() = std::abs(in1() - in2()) <= (atol + rtol * std::abs(in2()));
 }
 
 } // namespace detail

--- a/ctmd/ctmd_multiply.hpp
+++ b/ctmd/ctmd_multiply.hpp
@@ -9,7 +9,7 @@ template <mdspan_c in1_t, mdspan_c in2_t, mdspan_c out_t>
     requires(in1_t::rank() == 0 && in2_t::rank() == 0 && out_t::rank() == 0)
 inline constexpr void multiply_impl(const in1_t &in1, const in2_t &in2,
                                     const out_t &out) noexcept {
-    out[] = in1[] * in2[];
+    out() = in1() * in2();
 }
 
 } // namespace detail

--- a/ctmd/ctmd_negative.hpp
+++ b/ctmd/ctmd_negative.hpp
@@ -8,7 +8,7 @@ namespace detail {
 template <mdspan_c in_t, mdspan_c out_t>
     requires(in_t::rank() == 0 && out_t::rank() == 0)
 inline constexpr void negative_impl(const in_t &in, const out_t &out) noexcept {
-    out[] = -in[];
+    out() = -in();
 }
 
 } // namespace detail

--- a/ctmd/ctmd_not_equal.hpp
+++ b/ctmd/ctmd_not_equal.hpp
@@ -9,7 +9,7 @@ template <mdspan_c in1_t, mdspan_c in2_t, mdspan_c out_t>
     requires(in1_t::rank() == 0 && in2_t::rank() == 0 && out_t::rank() == 0)
 inline constexpr void not_equal_impl(const in1_t &in1, const in2_t &in2,
                                      const out_t &out) noexcept {
-    out[] = (in1[] != in2[]);
+    out() = (in1() != in2());
 }
 
 } // namespace detail

--- a/ctmd/ctmd_subtract.hpp
+++ b/ctmd/ctmd_subtract.hpp
@@ -9,7 +9,7 @@ template <mdspan_c in1_t, mdspan_c in2_t, mdspan_c out_t>
     requires(in1_t::rank() == 0 && in2_t::rank() == 0 && out_t::rank() == 0)
 inline constexpr void subtract_impl(const in1_t &in1, const in2_t &in2,
                                     const out_t &out) noexcept {
-    out[] = in1[] - in2[];
+    out() = in1() - in2();
 }
 
 } // namespace detail

--- a/ctmd/linalg/ctmd_linalg_inv.hpp
+++ b/ctmd/linalg/ctmd_linalg_inv.hpp
@@ -19,12 +19,12 @@ inline constexpr void inv_naive(const in_t &in, const out_t &out) noexcept {
     auto in_copy = copy(in);
     for (size_t i = 0; i < n; i++) {
         for (size_t j = 0; j < n; j++) {
-            out[i, j] = (i == j) ? 1 : 0;
+            out(i, j) = (i == j) ? 1 : 0;
         }
     }
 
     for (size_t i = 0; i < n; i++) {
-        const TO pivot = in_copy[i, i];
+        const TO pivot = in_copy(i, i);
 
         if (pivot == TO(0)) {
             // Handle error: singular matrix (no inverse)
@@ -33,8 +33,8 @@ inline constexpr void inv_naive(const in_t &in, const out_t &out) noexcept {
 
         // Normalize the pivot row
         for (size_t j = 0; j < n; j++) {
-            in_copy[i, j] /= pivot;
-            out[i, j] /= pivot;
+            in_copy(i, j) /= pivot;
+            out(i, j) /= pivot;
         }
 
         // Eliminate other rows
@@ -42,10 +42,10 @@ inline constexpr void inv_naive(const in_t &in, const out_t &out) noexcept {
             if (i == j)
                 continue;
 
-            TO factor = in_copy[j, i];
+            TO factor = in_copy(j, i);
             for (size_t k = 0; k < n; k++) {
-                in_copy[j, k] -= factor * in_copy[i, k];
-                out[j, k] -= factor * out[i, k];
+                in_copy(j, k) -= factor * in_copy(i, k);
+                out(j, k) -= factor * out(i, k);
             }
         }
     }

--- a/ctmd/linalg/ctmd_linalg_matmul.hpp
+++ b/ctmd/linalg/ctmd_linalg_matmul.hpp
@@ -17,9 +17,9 @@ inline constexpr void matmul_naive(const in1_t &in1, const in2_t &in2,
             core::to_mdspan(out).data_handle()) [[likely]] {
         for (typename out_t::size_type i = 0; i < out.extent(0); i++) {
             for (typename out_t::size_type j = 0; j < out.extent(1); j++) {
-                out[i, j] = 0;
+                out(i, j) = 0;
                 for (typename in1_t::size_type k = 0; k < in1.extent(1); k++) {
-                    out[i, j] += in1[i, k] * in2[k, j];
+                    out(i, j) += in1(i, k) * in2(k, j);
                 }
             }
         }

--- a/ctmd/linalg/ctmd_linalg_matvec.hpp
+++ b/ctmd/linalg/ctmd_linalg_matvec.hpp
@@ -16,9 +16,9 @@ inline constexpr void matvec_naive(const in1_t &in1, const in2_t &in2,
         core::to_mdspan(in2).data_handle() !=
             core::to_mdspan(out).data_handle()) [[likely]] {
         for (typename out_t::size_type i = 0; i < out.extent(0); i++) {
-            out[i] = 0;
+            out(i) = 0;
             for (typename in1_t::size_type j = 0; j < in1.extent(1); j++) {
-                out[i] += in1[i, j] * in2[j];
+                out(i) += in1(i, j) * in2(j);
             }
         }
 

--- a/ctmd/linalg/ctmd_linalg_norm.hpp
+++ b/ctmd/linalg/ctmd_linalg_norm.hpp
@@ -11,11 +11,11 @@ namespace detail {
 template <mdspan_c in_t, mdspan_c out_t>
     requires(in_t::rank() == 1 && out_t::rank() == 0)
 inline constexpr void norm_impl(const in_t &in, const out_t &out) noexcept {
-    out[] = 0;
+    out() = 0;
     for (typename in_t::size_type i = 0; i < in.extent(0); i++) {
-        out[] += in[i] * in[i];
+        out() += in[i] * in[i];
     }
-    out[] = std::sqrt(out[]);
+    out() = std::sqrt(out());
 }
 
 } // namespace detail

--- a/ctmd/linalg/ctmd_linalg_vecmat.hpp
+++ b/ctmd/linalg/ctmd_linalg_vecmat.hpp
@@ -16,9 +16,9 @@ inline constexpr void vecmat_naive(const in1_t &in1, const in2_t &in2,
         core::to_mdspan(in2).data_handle() !=
             core::to_mdspan(out).data_handle()) [[likely]] {
         for (typename out_t::size_type i = 0; i < out.extent(0); i++) {
-            out[i] = 0;
+            out(i) = 0;
             for (typename in1_t::size_type j = 0; j < in1.extent(0); j++) {
-                out[i] += in1[j] * in2[j, i];
+                out(i) += in1(j) * in2(j, i);
             }
         }
 

--- a/ctmd/random/ctmd_random_rand.hpp
+++ b/ctmd/random/ctmd_random_rand.hpp
@@ -55,7 +55,7 @@ template <typename T, std::size_t sz>
 
 template <mdspan_c in_t>
     requires(in_t::rank() == 0 && floating_point_c<typename in_t::element_type>)
-inline constexpr void rand_impl(const in_t &in) noexcept {
+inline void rand_impl(const in_t &in) noexcept {
     using T = typename in_t::element_type;
     using dist_t = std::uniform_real_distribution<T>;
 
@@ -63,7 +63,7 @@ inline constexpr void rand_impl(const in_t &in) noexcept {
     thread_local static auto gen = std::mt19937(rd());
     static auto dist = dist_t{0, 1};
 
-    in[] = dist(gen);
+    in() = dist(gen);
 }
 
 } // namespace detail
@@ -80,7 +80,7 @@ inline constexpr void rand(in_t &in,
             if constexpr (decltype(rin)::rank() == 0) {
                 constexpr auto data =
                     detail::uniform_distribution<T, 1>(0, 1)[0];
-                rin[] = data;
+                rin() = data;
 
             } else {
                 constexpr auto data_size =

--- a/tests/clip/main.cpp
+++ b/tests/clip/main.cpp
@@ -19,8 +19,8 @@ TEST(stack, clip) {
     for (size_t i = 0; i < a.extent(0); i++) {
         for (size_t j = 0; j < a.extent(1); j++) {
             for (size_t k = 0; k < a.extent(2); k++) {
-                ASSERT_TRUE((a_min[0] <= a_clip[i, j, k] &&
-                             a_clip[i, j, k] <= a_max[0]));
+                ASSERT_TRUE((a_min(0) <= a_clip(i, j, k) &&
+                             a_clip(i, j, k) <= a_max(0)));
             }
         }
     }
@@ -39,7 +39,7 @@ TEST(stack, clip_scalar) {
         for (size_t j = 0; j < a.extent(1); j++) {
             for (size_t k = 0; k < a.extent(2); k++) {
                 ASSERT_TRUE(
-                    (a_min <= a_clip[i, j, k] && a_clip[i, j, k] <= a_max));
+                    (a_min <= a_clip(i, j, k) && a_clip(i, j, k) <= a_max));
             }
         }
     }
@@ -59,8 +59,8 @@ TEST(heap, clip) {
     for (size_t i = 0; i < a.extent(0); i++) {
         for (size_t j = 0; j < a.extent(1); j++) {
             for (size_t k = 0; k < a.extent(2); k++) {
-                ASSERT_TRUE((a_min[0] <= a_clip[i, j, k] &&
-                             a_clip[i, j, k] <= a_max[0]));
+                ASSERT_TRUE((a_min(0) <= a_clip(i, j, k) &&
+                             a_clip(i, j, k) <= a_max(0)));
             }
         }
     }
@@ -79,7 +79,7 @@ TEST(heap, clip_scalar) {
         for (size_t j = 0; j < a.extent(1); j++) {
             for (size_t k = 0; k < a.extent(2); k++) {
                 ASSERT_TRUE(
-                    (a_min <= a_clip[i, j, k] && a_clip[i, j, k] <= a_max));
+                    (a_min <= a_clip(i, j, k) && a_clip(i, j, k) <= a_max));
             }
         }
     }

--- a/tests/random/rand/main.cpp
+++ b/tests/random/rand/main.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "ctmd/ctmd_array_equiv.hpp"
+#include "ctmd/ctmd_to_string.hpp"
 #include "ctmd/random/ctmd_random_rand.hpp"
 
 namespace md = ctmd;
@@ -10,6 +11,8 @@ TEST(stack, 1) {
 
     constexpr auto out = md::random::rand<T, md::extents<size_t, 2, 2>>();
 
+    std::cout << md::to_string(out) << std::endl;
+
     ASSERT_TRUE(!md::array_equiv(out, 0));
 }
 
@@ -17,6 +20,8 @@ TEST(stack, 2) {
     using T = double;
 
     constexpr auto out = md::random::rand<T>();
+
+    std::cout << md::to_string(out) << std::endl;
 
     ASSERT_TRUE(!md::array_equiv(out, 0));
 }
@@ -26,6 +31,8 @@ TEST(heap, 1) {
 
     const auto out = md::random::rand<T, md::dims<2>>(md::dims<2>{2, 2});
 
+    std::cout << md::to_string(out) << std::endl;
+
     ASSERT_TRUE(!md::array_equiv(out, 0));
 }
 
@@ -33,6 +40,8 @@ TEST(heap, 2) {
     using T = double;
 
     const auto out = md::random::rand<T>();
+
+    std::cout << md::to_string(out) << std::endl;
 
     ASSERT_TRUE(!md::array_equiv(out, 0));
 }


### PR DESCRIPTION
This pull request updates the codebase to improve compatibility with C++20 by adjusting compiler settings and modifying syntax for `mdspan` usage. The most significant changes include downgrading the C++ standard from C++23 to C++20, updating `mdspan` access syntax from `[]` to `()`, and ensuring compatibility through updated macro definitions.

### Compiler and Build Configuration:
* [`.bazelrc`](diffhunk://#diff-544556920c45b42cbfe40159b082ce8af6bd929e492d076769226265f215832fL1-R3): Downgraded the C++ standard from C++23 to C++20 for build, run, and test configurations. (`[.bazelrcL1-R3](diffhunk://#diff-544556920c45b42cbfe40159b082ce8af6bd929e492d076769226265f215832fL1-R3)`)
* [`WORKSPACE`](diffhunk://#diff-5493ff8e9397811510e780de47c57abb70137f1afe85d1519130dc3679d60ce5L89-R89): Updated the `MDSPAN_USE_BRACKET_OPERATOR` macro to `0` for compatibility with C++20. (`[WORKSPACEL89-R89](diffhunk://#diff-5493ff8e9397811510e780de47c57abb70137f1afe85d1519130dc3679d60ce5L89-R89)`)

### Syntax Updates for `mdspan`:
* Replaced `[]` with `()` for `mdspan` access in multiple files to align with C++20 requirements:
  - `ctmd/ctmd_add.hpp`, `ctmd/ctmd_all.hpp`, `ctmd/ctmd_array_equal.hpp`, `ctmd/ctmd_clip.hpp`, `ctmd/ctmd_copy.hpp`, `ctmd/ctmd_divide.hpp`, `ctmd/ctmd_equal.hpp`, `ctmd/ctmd_fill.hpp`, `ctmd/ctmd_isclose.hpp`, `ctmd/ctmd_multiply.hpp`, `ctmd/ctmd_negative.hpp`, `ctmd/ctmd_not_equal.hpp`, `ctmd/ctmd_subtract.hpp`. (Multiple references: `[[1]](diffhunk://#diff-bd3b324b8e59310aa8e4dcc7aaaac891c4a394c1ee586c0ab937dd9a826fdf76L12-R12)`, `[[2]](diffhunk://#diff-a15dfce48e59d234962adfb8a3d72f87e1a9b541ca224cbc8945d364d912656aL17-R17)`, `[[3]](diffhunk://#diff-f821a84edba9a7dc4c4da8cf98c1f8ecc1234b54b9a7283928e367346db3ef64L26-R26)`, `[[4]](diffhunk://#diff-7ffbf967a6abe4bc33b653d0b869bb96ce9a41097821f13c4ea9a5089a5b4280L13-R14)`, `[[5]](diffhunk://#diff-251e2cff3eaa819f15c6fe53e9e08f82cf946606742a8c061ff31682b6a0d21bL11-R11)`, `[[6]](diffhunk://#diff-6bfd1cd2bc8013e405cc32df92df18c79883e4a87f01d8b6218e58d6d825587cL12-R12)`, `[[7]](diffhunk://#diff-a210a6c7ed5bbfb7902dfcbd74beeb46065adf5feecab9b84a8f22a3f803f4f3L12-R12)`, `[[8]](diffhunk://#diff-26bfecd39f21b5da4ec7a752918a6fcc823c56e1d91d7e3841ebab3775affa94L11-R11)`, `[[9]](diffhunk://#diff-130b8b210081fc5c1d9735832ea66e732103907376acd962d02646a1c1ce8058L14-R14)`, `[[10]](diffhunk://#diff-1bb66ffe32c8d97e6c52a28637ea06c9bb2c0726d227e4b28bc5d7ae1b0682ceL12-R12)`, `[[11]](diffhunk://#diff-2bd1c00deba4e98c48b3c522ed4377a4325244be744e2c62e6a4efd13852a957L11-R11)`, `[[12]](diffhunk://#diff-aecd28633a2a2115271039ec42e3cfcfa6dd40416420b100cba702df29feaed2L12-R12)`, `[[13]](diffhunk://#diff-9d1846a3d73463a7f757954b07aa80d7c25c23304b813da91de09e62fb6fc39aL12-R12)`)

### Linear Algebra Operations:
* Updated `mdspan` access syntax in linear algebra operations for consistency:
  - `ctmd/linalg/ctmd_linalg_inv.hpp`, `ctmd/linalg/ctmd_linalg_matmul.hpp`, `ctmd/linalg/ctmd_linalg_matvec.hpp`, `ctmd/linalg/ctmd_linalg_norm.hpp`, `ctmd/linalg/ctmd_linalg_vecmat.hpp`. (References: `[[1]](diffhunk://#diff-1a9aa3facb5e09145154870e0a418a7f09a227ea63908e99f13dbd5c9bbf6af8L22-R27)`, `[[2]](diffhunk://#diff-1a9aa3facb5e09145154870e0a418a7f09a227ea63908e99f13dbd5c9bbf6af8L36-R48)`, `[[3]](diffhunk://#diff-e0a4b0ce006a8e5a57ae10dafeb409e85b100e49b186860b7468af9f8fdc0099L20-R22)`, `[[4]](diffhunk://#diff-4dd5786f9e53d802dd59ea399dd7184dd7a145c332d52fcbf809d14c101202f9L19-R21)`, `[[5]](diffhunk://#diff-27fcbc08415935b1280fc69a8cfce3ed8bc5dbf80cfbfc170df7eed4237aa420L14-R18)`, `[[6]](diffhunk://#diff-23223afc4b14813f6e654d8d4b7b5e04c5332dbc71465f0c60242efa87639472L19-R21)`)