### PR TITLE
Update ctmd_clip.hpp

### DIFF
--- a/ctmd/ctmd_clip.hpp
+++ b/ctmd/ctmd_clip.hpp
@@ -10,8 +10,9 @@ template <mdspan_c in_t, mdspan_c min_t, mdspan_c max_t, mdspan_c out_t>
              out_t::rank() == 0)
 inline constexpr void clip_impl(const in_t &in, const min_t &min,
                                 const max_t &max, const out_t &out) noexcept {
-    out() = std::clamp(in(), static_cast<decltype(in())>(min()),
-                       static_cast<decltype(in())>(max()));
+    out() = std::clamp(in(),
+                       static_cast<std::remove_cvref_t<decltype(in())>>(min()),
+                       static_cast<std::remove_cvref_t<decltype(in())>>(max()));
 }
 
 } // namespace detail


### PR DESCRIPTION
This pull request updates the `clip_impl` function in `ctmd/ctmd_clip.hpp` to improve type safety by ensuring consistent type handling for the `min` and `max` parameters. 

Type safety improvement:

* [`ctmd/ctmd_clip.hpp`](diffhunk://#diff-7ffbf967a6abe4bc33b653d0b869bb96ce9a41097821f13c4ea9a5089a5b4280L13-R15): Updated the `clip_impl` function to use `std::remove_cvref_t` for the `min` and `max` parameters, ensuring that the types are stripped of const, volatile, and reference qualifiers before performing the `std::clamp` operation.