### PR TITLE
Update ctmd_expand_dims.hpp

### DIFF
--- a/ctmd/ctmd_expand_dims.hpp
+++ b/ctmd/ctmd_expand_dims.hpp
@@ -18,7 +18,8 @@ template <int64_t Axis, typename in_t>
 
     } else {
         constexpr size_t axis = static_cast<size_t>(
-            ((Axis % (rank + 1)) + (rank + 1)) % (rank + 1));
+            ((Axis % static_cast<int64_t>(rank + 1)) + (rank + 1)) %
+            (rank + 1));
 
         const auto new_extents =
             [&rin]<size_t... Is>(std::index_sequence<Is...>) {


### PR DESCRIPTION
This pull request includes a minor fix to the `ctmd_expand_dims.hpp` file. The change ensures that the calculation of the `axis` variable uses consistent type casting for `rank + 1` to avoid potential type mismatch issues.

* [`ctmd/ctmd_expand_dims.hpp`](diffhunk://#diff-3bce79ed49615d988939fc4c67fd16e18746bc3cd271fc7514cb778821da0bdfL21-R22): Updated the `Axis` calculation to explicitly cast `rank + 1` to `int64_t` for consistency in the modulo operation.