### PR TITLE
Feature sum

### DIFF
--- a/benchmarks/linalg/norm/BUILD.bazel
+++ b/benchmarks/linalg/norm/BUILD.bazel
@@ -158,6 +158,7 @@ cc_binary(
         ],
     copts = [
         "-O3",
+        # "-Ofast",
         "-funroll-loops",
         "-fno-rtti",
         "-Wall",
@@ -177,6 +178,7 @@ cc_binary(
         ],
     copts = [
         "-O3",
+        # "-Ofast",
         "-funroll-loops",
         "-fno-rtti",
         "-Wall",

--- a/ctmd/core/ctmd_core_broadcast.hpp
+++ b/ctmd/core/ctmd_core_broadcast.hpp
@@ -358,23 +358,17 @@ inline constexpr void batch(Func &&func, const std::tuple<ins_t...> &ins,
                 std::tuple_element_t<0, std::tuple<ins_t...>>::rank() -
                 std::tuple_element_t<0, std::tuple<uinexts_t...>>::rank();
 
-            if (mpmode == MPMode::NONE || std::is_constant_evaluated())
-                [[likely]] {
-                detail::batch_impl<brank>(std::forward<Func>(func), ins, args);
-
-            } else if (mpmode == MPMode::CPUMP) {
+            if (mpmode == MPMode::CPUMP) [[unlikely]] {
 #ifdef _OPENMP
                 detail::batch_impl_cpump<brank>(std::forward<Func>(func), ins,
                                                 args);
-
+                return;
 #else
                 assert(false);
-
 #endif
-            } else {
-                assert(false);
             }
 
+            detail::batch_impl<brank>(std::forward<Func>(func), ins, args);
             return;
         }
     }
@@ -395,21 +389,16 @@ inline constexpr void batch(Func &&func, const std::tuple<ins_t...> &ins,
             std::get<Is>(ins), concatenate(bexts, std::get<Is>(uinexts)))...};
     }(std::make_index_sequence<sizeof...(ins_t)>{});
 
-    if (mpmode == MPMode::NONE || std::is_constant_evaluated()) [[likely]] {
-        detail::batch_impl<brank>(std::forward<Func>(func), bins, args);
-
-    } else if (mpmode == MPMode::CPUMP) {
+    if (mpmode == MPMode::CPUMP) [[unlikely]] {
 #ifdef _OPENMP
         detail::batch_impl_cpump<brank>(std::forward<Func>(func), bins, args);
-
+        return;
 #else
         assert(false);
-
 #endif
-
-    } else {
-        assert(false);
     }
+
+    detail::batch_impl<brank>(std::forward<Func>(func), bins, args);
 }
 
 template <typename Func, mdspan_c... ins_t, extents_c... uinexts_t,
@@ -460,24 +449,17 @@ inline constexpr auto batch(Func &&func, const std::tuple<ins_t...> &ins,
                 return std::tuple{std::get<Is>(ins)..., to_mdspan(out)};
             }(std::make_index_sequence<sizeof...(ins_t)>{});
 
-            if (mpmode == MPMode::NONE || std::is_constant_evaluated())
-                [[likely]] {
-                detail::batch_impl<brank>(std::forward<Func>(func), bins, args);
-
-            } else if (mpmode == MPMode::CPUMP) {
+            if (mpmode == MPMode::CPUMP) [[unlikely]] {
 #ifdef _OPENMP
                 detail::batch_impl_cpump<brank>(std::forward<Func>(func), bins,
                                                 args);
-
+                return out;
 #else
                 assert(false);
-
 #endif
-
-            } else {
-                assert(false);
             }
 
+            detail::batch_impl<brank>(std::forward<Func>(func), bins, args);
             return out;
         }
     }
@@ -490,22 +472,16 @@ inline constexpr auto batch(Func &&func, const std::tuple<ins_t...> &ins,
             to_mdspan(out)};
     }(std::make_index_sequence<sizeof...(ins_t)>{});
 
-    if (mpmode == MPMode::NONE || std::is_constant_evaluated()) [[likely]] {
-        detail::batch_impl<brank>(std::forward<Func>(func), bins, args);
-
-    } else if (mpmode == MPMode::CPUMP) {
+    if (mpmode == MPMode::CPUMP) [[unlikely]] {
 #ifdef _OPENMP
         detail::batch_impl_cpump<brank>(std::forward<Func>(func), bins, args);
-
+        return out;
 #else
         assert(false);
-
 #endif
-
-    } else {
-        assert(false);
     }
 
+    detail::batch_impl<brank>(std::forward<Func>(func), bins, args);
     return out;
 }
 
@@ -563,24 +539,17 @@ inline constexpr auto batch(Func &&func, const std::tuple<ins_t...> &ins,
                            std::tuple_size_v<decltype(outs)>>{});
             }(std::make_index_sequence<sizeof...(ins_t)>{});
 
-            if (mpmode == MPMode::NONE || std::is_constant_evaluated())
-                [[likely]] {
-                detail::batch_impl<brank>(std::forward<Func>(func), bins, args);
-
-            } else if (mpmode == MPMode::CPUMP) {
+            if (mpmode == MPMode::CPUMP) [[unlikely]] {
 #ifdef _OPENMP
                 detail::batch_impl_cpump<brank>(std::forward<Func>(func), bins,
                                                 args);
-
+                return outs;
 #else
                 assert(false);
-
 #endif
-
-            } else {
-                assert(false);
             }
 
+            detail::batch_impl<brank>(std::forward<Func>(func), bins, args);
             return outs;
         }
     }
@@ -596,22 +565,16 @@ inline constexpr auto batch(Func &&func, const std::tuple<ins_t...> &ins,
         }(std::make_index_sequence<std::tuple_size_v<decltype(outs)>>{});
     }(std::make_index_sequence<sizeof...(ins_t)>{});
 
-    if (mpmode == MPMode::NONE || std::is_constant_evaluated()) [[likely]] {
-        detail::batch_impl<brank>(std::forward<Func>(func), bins, args);
-
-    } else if (mpmode == MPMode::CPUMP) {
+    if (mpmode == MPMode::CPUMP) [[unlikely]] {
 #ifdef _OPENMP
         detail::batch_impl_cpump<brank>(std::forward<Func>(func), bins, args);
-
+        return outs;
 #else
         assert(false);
-
 #endif
-
-    } else {
-        assert(false);
     }
 
+    detail::batch_impl<brank>(std::forward<Func>(func), bins, args);
     return outs;
 }
 

--- a/ctmd/core/ctmd_core_type.hpp
+++ b/ctmd/core/ctmd_core_type.hpp
@@ -109,7 +109,11 @@ using slice = std::experimental::strided_slice<
     std::integral_constant<size_t, end - start>,
     std::integral_constant<size_t, 1>>;
 
-enum class MPMode : uint8_t { NONE, CPUMP };
+enum class MPMode : uint8_t {
+    NONE,
+    SIMD, // NOTE: Testing
+    CPUMP,
+};
 
 template <typename T> struct element_type {
     using type = T;

--- a/ctmd/ctmd_sum.hpp
+++ b/ctmd/ctmd_sum.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "core/ctmd_core.hpp"
+#include "ctmd_add.hpp"
+#include "ctmd_fill.hpp"
+
+namespace ctmd {
+namespace detail {
+
+template <mdspan_c in_t, mdspan_c out_t>
+    requires(in_t::rank() - out_t::rank() == 1)
+inline constexpr void sum_impl(const in_t &in, const out_t &out) noexcept {
+    ctmd::fill(out, 0);
+
+    for (typename in_t::size_type i = 0; i < in.extent(0); i++) {
+        ctmd::add(out, core::submdspan_from_start(in, i), out);
+    }
+}
+
+} // namespace detail
+
+template <int64_t Axis, typename in_t, typename out_t>
+inline constexpr void sum(in_t &&in, out_t &&out,
+                          const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto rin = core::to_mdspan(std::forward<in_t>(in));
+    const auto rout = core::to_mdspan(std::forward<out_t>(out));
+
+    constexpr size_t urin_rank =
+        rin.rank() -
+        static_cast<size_t>(
+            ((Axis % static_cast<int64_t>(rin.rank())) + (rin.rank())) %
+            (rin.rank()));
+
+    const auto urin_exts = core::slice_from_start<urin_rank>(rin.extents());
+    const auto urout_exts =
+        core::slice_from_start<urin_rank - 1>(rout.extents());
+
+    core::batch(
+        [](const auto &in, const auto &out) { detail::sum_impl(in, out); },
+        std::tuple{rin, rout}, std::tuple{urin_exts, urout_exts}, std::tuple{},
+        mpmode);
+}
+
+template <int64_t Axis, typename in_t>
+[[nodiscard]] inline constexpr auto
+sum(in_t &&in, const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto rin = core::to_mdspan(std::forward<in_t>(in));
+
+    constexpr size_t urin_rank =
+        rin.rank() -
+        static_cast<size_t>(
+            ((Axis % static_cast<int64_t>(rin.rank())) + (rin.rank())) %
+            (rin.rank()));
+
+    const auto urin_exts = core::slice_from_start<urin_rank>(rin.extents());
+    const auto urout_exts = core::slice_from_last<urin_rank - 1>(urin_exts);
+
+    return core::batch(
+        [](const auto &in, const auto &out) { detail::sum_impl(in, out); },
+        std::tuple{rin}, std::tuple{urin_exts, urout_exts}, std::tuple{},
+        mpmode);
+}
+
+} // namespace ctmd

--- a/tests/sum/BUILD.bazel
+++ b/tests/sum/BUILD.bazel
@@ -1,0 +1,17 @@
+cc_test(
+    name = "main",
+    srcs = [
+        "main.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@gtest//:gtest_main",
+        "//:ctmd",
+    ],
+)

--- a/tests/sum/main.cpp
+++ b/tests/sum/main.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+
+#include "ctmd/ctmd_allclose.hpp"
+#include "ctmd/ctmd_sum.hpp"
+
+namespace md = ctmd;
+
+TEST(stack, copy) {
+    using T = double;
+
+    constexpr auto in = md::mdarray<T, md::extents<size_t, 2, 3>>{
+        std::array<T, 6>{1, 2, 3, 4, 5, 6}};
+
+    static_assert(md::allclose(
+        md::sum<-1>(in),
+        md::mdarray<T, md::extents<size_t, 2>>{std::array<T, 2>{6, 15}}));
+
+    static_assert(md::allclose(
+        md::sum<0>(in),
+        md::mdarray<T, md::extents<size_t, 3>>{std::array<T, 3>{5, 7, 9}}));
+
+    static_assert(md::allclose(
+        md::sum<1>(in),
+        md::mdarray<T, md::extents<size_t, 2>>{std::array<T, 2>{6, 15}}));
+}
+
+TEST(heap, copy) {
+    using T = double;
+
+    const auto in = md::mdarray<T, md::dims<2>>{
+        std::vector<T>{1, 2, 3, 4, 5, 6}, md::dims<2>{2, 3}};
+
+    ASSERT_TRUE(md::allclose(
+        md::sum<-1>(in),
+        md::mdarray<T, md::dims<1>>{std::vector<T>{6, 15}, md::dims<1>{2}}));
+
+    ASSERT_TRUE(md::allclose(
+        md::sum<0>(in),
+        md::mdarray<T, md::dims<1>>{std::vector<T>{5, 7, 9}, md::dims<1>{3}}));
+
+    ASSERT_TRUE(md::allclose(
+        md::sum<1>(in),
+        md::mdarray<T, md::dims<1>>{std::vector<T>{6, 15}, md::dims<1>{2}}));
+}


### PR DESCRIPTION
This pull request introduces several changes to enhance functionality, improve performance, and add new features to the `ctmd` library. Key updates include the addition of a new `sum` operation, modifications to the `batch` function for better handling of parallelization modes, and expanded support for SIMD operations in the `norm` function. Additionally, new tests were added to validate the `sum` functionality.

### New Features:
* Added a `sum` operation in `ctmd/ctmd_sum.hpp` to compute the sum along a specified axis, with support for multiple parallelization modes (`MPMode`).
* Introduced a new SIMD-based implementation for the `norm` function in `ctmd/linalg/ctmd_linalg_norm.hpp`, leveraging `multiply`, `sum`, and `sqrt` operations for performance optimization.

### Parallelization Enhancements:
* Refactored the `batch` function in `ctmd/core/ctmd_core_broadcast.hpp` to streamline handling of different `MPMode` cases, including removal of redundant checks and improved flow for `CPUMP` mode. [[1]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749L361-R371) [[2]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749L398-R401) [[3]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749L463-R462) [[4]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749L493-R484) [[5]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749L566-R552) [[6]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749L599-R577)
* Added a new `SIMD` mode to the `MPMode` enum in `ctmd/core/ctmd_core_type.hpp` for testing and future SIMD optimizations.

### Testing and Validation:
* Added a new test suite in `tests/sum/main.cpp` to validate the correctness of the `sum` operation for both statically and dynamically allocated arrays.
* Created a corresponding Bazel build rule in `tests/sum/BUILD.bazel` for the new test suite.

### Minor Changes:
* Updated `benchmarks/linalg/norm/BUILD.bazel` to comment out the `-Ofast` optimization flag for better compatibility and debugging. [[1]](diffhunk://#diff-ba3c59b2dbc0c415c4e8355cd6c5d8e389c80c5121822e59cf065d0b0775ca06R161) [[2]](diffhunk://#diff-ba3c59b2dbc0c415c4e8355cd6c5d8e389c80c5121822e59cf065d0b0775ca06R181)
* Included additional headers in `ctmd/linalg/ctmd_linalg_norm.hpp` to support new functionality (`ctmd_multiply`, `ctmd_sqrt`, `ctmd_sum`).