### PR TITLE
Feature reshape

### DIFF
--- a/ctmd/ctmd.hpp
+++ b/ctmd/ctmd.hpp
@@ -23,6 +23,7 @@
 #include "ctmd_multiply.hpp"
 #include "ctmd_negative.hpp"
 #include "ctmd_not_equal.hpp"
+#include "ctmd_reshape.hpp"
 #include "ctmd_sin.hpp"
 #include "ctmd_sqrt.hpp"
 #include "ctmd_subtract.hpp"

--- a/ctmd/ctmd_expand_dims.hpp
+++ b/ctmd/ctmd_expand_dims.hpp
@@ -1,20 +1,20 @@
 #pragma once
 
-#include "core/ctmd_core.hpp"
+#include "ctmd_reshape.hpp"
 
 namespace ctmd {
 
-template <int64_t Axis, typename in_t>
-[[nodiscard]] inline constexpr auto expand_dims(in_t &&in) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-    using rin_t = decltype(rin);
+template <int64_t Axis, typename InType>
+[[nodiscard]] inline constexpr auto expand_dims(InType &&In) noexcept {
+    const auto in = core::to_mdspan(std::forward<InType>(In));
+    using in_t = decltype(in);
 
-    constexpr size_t rank = rin_t::rank();
+    constexpr size_t rank = in_t::rank();
 
     if constexpr (rank == 0) {
-        auto new_extents = extents<typename rin_t::index_type, 1>{1};
-        return mdspan<typename rin_t::element_type, decltype(new_extents)>{
-            rin.data_handle(), new_extents};
+        auto new_extents = extents<typename in_t::index_type, 1>{1};
+        return mdspan<typename in_t::element_type, decltype(new_extents)>{
+            in.data_handle(), new_extents};
 
     } else {
         constexpr size_t axis = static_cast<size_t>(
@@ -22,28 +22,17 @@ template <int64_t Axis, typename in_t>
             (rank + 1));
 
         const auto new_extents =
-            [&rin]<size_t... Is>(std::index_sequence<Is...>) {
+            [&in]<size_t... Is>(std::index_sequence<Is...>) {
                 return extents<
-                    typename rin_t::index_type,
+                    typename in_t::index_type,
                     (Is < axis
-                         ? rin_t::static_extent(Is)
-                         : (Is == axis ? 1 : rin_t::static_extent(Is - 1)))...>{
-                    (Is < axis ? rin.extent(Is)
-                               : (Is == axis ? 1 : rin.extent(Is - 1)))...};
+                         ? in_t::static_extent(Is)
+                         : (Is == axis ? 1 : in_t::static_extent(Is - 1)))...>{
+                    (Is < axis ? in.extent(Is)
+                               : (Is == axis ? 1 : in.extent(Is - 1)))...};
             }(std::make_index_sequence<rank + 1>{});
 
-        const auto new_strides =
-            [&rin]<size_t... Is>(std::index_sequence<Is...>) {
-                return std::array<typename rin_t::size_type, rank + 1>{
-                    (Is < axis ? rin.stride(Is)
-                               : (Is == axis ? 1 : rin.stride(Is - 1)))...};
-            }(std::make_index_sequence<rank + 1>{});
-
-        return mdspan<typename rin_t::element_type,
-                      std::remove_const_t<decltype(new_extents)>, layout_stride,
-                      typename rin_t::accessor_type>{
-            rin.data_handle(),
-            layout_stride::mapping{new_extents, new_strides}};
+        return reshape(std::forward<InType>(In), new_extents);
     }
 }
 

--- a/ctmd/ctmd_reshape.hpp
+++ b/ctmd/ctmd_reshape.hpp
@@ -33,17 +33,12 @@ reshape(InType &&In, const extents_t &new_extents = extents_t{}) noexcept {
         assert(in.is_unique());
         assert(in.is_exhaustive());
         assert(in.is_strided());
-
-        const size_t in_size = [&in]<size_t... Is>(std::index_sequence<Is...>) {
+        assert([&in]<size_t... Is>(std::index_sequence<Is...>) {
             return ((in.extent(Is) * ...));
-        }(std::make_index_sequence<in_t::rank()>{});
-
-        const size_t new_size =
-            [&new_extents]<size_t... Is>(std::index_sequence<Is...>) {
-                return ((new_extents.extent(Is) * ...));
-            }(std::make_index_sequence<extents_t::rank()>{});
-
-        assert(in_size == new_size);
+        }(std::make_index_sequence<in_t::rank()>{}) ==
+               [&new_extents]<size_t... Is>(std::index_sequence<Is...>) {
+                   return ((new_extents.extent(Is) * ...));
+               }(std::make_index_sequence<extents_t::rank()>{}));
 
         return mdspan<typename in_t::element_type, extents_t>{in.data_handle(),
                                                               new_extents};

--- a/ctmd/ctmd_reshape.hpp
+++ b/ctmd/ctmd_reshape.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "core/ctmd_core.hpp"
+
+namespace ctmd {
+
+template <typename InType, extents_c extents_t>
+[[nodiscard]] inline constexpr auto
+reshape(InType &&In, const extents_t &new_extents = extents_t{}) noexcept {
+    const auto in = core::to_mdspan(std::forward<InType>(In));
+    using in_t = decltype(in);
+
+    if constexpr (in_t::is_always_unique() && in_t::is_always_exhaustive() &&
+                  in_t::is_always_strided() && in_t::rank_dynamic() == 0 &&
+                  extents_t::rank_dynamic() == 0) {
+        constexpr size_t in_size =
+            []<size_t... Is>(std::index_sequence<Is...>) {
+                return ((in_t::static_extent(Is) * ...));
+            }(std::make_index_sequence<in_t::rank()>{});
+        constexpr size_t new_size =
+            []<size_t... Is>(std::index_sequence<Is...>) {
+                return ((extents_t::static_extent(Is) * ...));
+            }(std::make_index_sequence<extents_t::rank()>{});
+
+        static_assert(in_size == new_size,
+                      "The number of elements in the input and output "
+                      "mdspan must be the same.");
+
+        return mdspan<typename in_t::element_type, extents_t>{in.data_handle(),
+                                                              new_extents};
+
+    } else {
+        assert(in.is_unique());
+        assert(in.is_exhaustive());
+        assert(in.is_strided());
+
+        const size_t in_size = [&in]<size_t... Is>(std::index_sequence<Is...>) {
+            return ((in.extent(Is) * ...));
+        }(std::make_index_sequence<in_t::rank()>{});
+
+        const size_t new_size =
+            [&new_extents]<size_t... Is>(std::index_sequence<Is...>) {
+                return ((new_extents.extent(Is) * ...));
+            }(std::make_index_sequence<extents_t::rank()>{});
+
+        assert(in_size == new_size);
+
+        return mdspan<typename in_t::element_type, extents_t>{in.data_handle(),
+                                                              new_extents};
+    }
+}
+
+} // namespace ctmd

--- a/tests/reshape/BUILD.bazel
+++ b/tests/reshape/BUILD.bazel
@@ -1,0 +1,17 @@
+cc_test(
+    name = "main",
+    srcs = [
+        "main.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@gtest//:gtest_main",
+        "//:ctmd",
+    ],
+)

--- a/tests/reshape/main.cpp
+++ b/tests/reshape/main.cpp
@@ -1,0 +1,33 @@
+#include <gtest/gtest.h>
+
+#include "ctmd/ctmd.hpp"
+
+namespace md = ctmd;
+
+TEST(stack, 1) {
+    using T = double;
+
+    constexpr auto in = md::mdarray<T, md::extents<size_t, 2, 3>>{
+        std::array<T, 6>{1, 2, 3, 4, 5, 6}};
+
+    constexpr bool array_equal =
+        md::array_equal(md::reshape(in, md::extents<size_t, 6>{}),
+                        md::mdarray<T, md::extents<size_t, 6>>{
+                            std::array<T, 6>{1, 2, 3, 4, 5, 6}});
+
+    ASSERT_TRUE(array_equal);
+}
+
+TEST(stack, 2) {
+    using T = double;
+
+    const auto in = md::mdarray<T, md::dims<2>>{
+        std::vector<T>{1, 2, 3, 4, 5, 6}, md::dims<2>{2, 3}};
+
+    const bool array_equal =
+        md::array_equal(md::reshape(in, md::extents<size_t, 6>{}),
+                        md::mdarray<T, md::dims<1>>{
+                            std::vector<T>{1, 2, 3, 4, 5, 6}, md::dims<1>{6}});
+
+    ASSERT_TRUE(array_equal);
+}


### PR DESCRIPTION
This pull request introduces a new `reshape` function to the `ctmd` library, refactors the `expand_dims` function to use `reshape` for improved maintainability, and adds corresponding tests to validate the functionality. The most important changes include adding the `reshape` implementation, modifying `expand_dims` to leverage it, and introducing unit tests.

### New Feature: `reshape` Function

* Implemented the `reshape` function in `ctmd/ctmd_reshape.hpp`, which provides a utility for reshaping `mdspan` objects while ensuring compatibility through static assertions and runtime checks.
* Added the `reshape` header to `ctmd.hpp` to make the function accessible across the library.

### Refactor: `expand_dims` Function

* Refactored `expand_dims` in `ctmd_expand_dims.hpp` to utilize the `reshape` function, simplifying the implementation and reducing code duplication.

### Testing: Validation for `reshape`

* Added a Bazel build configuration for `reshape` tests in `tests/reshape/BUILD.bazel`.
* Created unit tests in `tests/reshape/main.cpp` to ensure the correctness of the `reshape` function for both compile-time and runtime scenarios.