### PR TITLE
develop

### DIFF
--- a/ctmd/core/ctmd_core_broadcast.hpp
+++ b/ctmd/core/ctmd_core_broadcast.hpp
@@ -6,6 +6,25 @@
 namespace ctmd {
 namespace core {
 
+template <extents_c in_t>
+[[nodiscard]] inline constexpr auto size(const in_t &in = in_t{}) noexcept {
+    if constexpr (in_t::rank_dynamic() == 0) {
+        return []<size_t... Is>(std::index_sequence<Is...>) {
+            return ((in_t::static_extent(Is) * ...));
+        }(std::make_index_sequence<in_t::rank()>{});
+
+    } else {
+        return [&in]<size_t... Is>(std::index_sequence<Is...>) {
+            return ((in.extent(Is) * ...));
+        }(std::make_index_sequence<in_t::rank()>{});
+    }
+}
+
+template <typename InType>
+[[nodiscard]] inline constexpr auto size(InType &&In) noexcept {
+    return size(core::to_mdspan(std::forward<InType>(In)).extents());
+}
+
 template <size_t SliceRank, extents_c in_t>
 [[nodiscard]] inline constexpr auto
 slice_from_start(const in_t &in = in_t{}) noexcept {

--- a/ctmd/ctmd_reshape.hpp
+++ b/ctmd/ctmd_reshape.hpp
@@ -13,14 +13,8 @@ reshape(InType &&In, const extents_t &new_extents = extents_t{}) noexcept {
     if constexpr (in_t::is_always_unique() && in_t::is_always_exhaustive() &&
                   in_t::is_always_strided() && in_t::rank_dynamic() == 0 &&
                   extents_t::rank_dynamic() == 0) {
-        constexpr size_t in_size =
-            []<size_t... Is>(std::index_sequence<Is...>) {
-                return ((in_t::static_extent(Is) * ...));
-            }(std::make_index_sequence<in_t::rank()>{});
-        constexpr size_t new_size =
-            []<size_t... Is>(std::index_sequence<Is...>) {
-                return ((extents_t::static_extent(Is) * ...));
-            }(std::make_index_sequence<extents_t::rank()>{});
+        constexpr size_t in_size = core::size<typename in_t::extents_type>();
+        constexpr size_t new_size = core::size<extents_t>();
 
         static_assert(in_size == new_size,
                       "The number of elements in the input and output "
@@ -33,12 +27,7 @@ reshape(InType &&In, const extents_t &new_extents = extents_t{}) noexcept {
         assert(in.is_unique());
         assert(in.is_exhaustive());
         assert(in.is_strided());
-        assert([&in]<size_t... Is>(std::index_sequence<Is...>) {
-            return ((in.extent(Is) * ...));
-        }(std::make_index_sequence<in_t::rank()>{}) ==
-               [&new_extents]<size_t... Is>(std::index_sequence<Is...>) {
-                   return ((new_extents.extent(Is) * ...));
-               }(std::make_index_sequence<extents_t::rank()>{}));
+        assert(core::size(in) == core::size(new_extents));
 
         return mdspan<typename in_t::element_type, extents_t>{in.data_handle(),
                                                               new_extents};


### PR DESCRIPTION
This pull request introduces a reusable `size` utility function in the `ctmd/core/ctmd_core_broadcast.hpp` file and refactors the `reshape` function in `ctmd/ctmd_reshape.hpp` to leverage this new utility. These changes aim to simplify the codebase, improve readability, and reduce duplication.

### New utility function:
* Added a `size` function template in `ctmd/core/ctmd_core_broadcast.hpp` to calculate the total size of an `extents_c` object or a compatible input type. This function handles both static and dynamic ranks, improving reusability and reducing boilerplate code.

### Refactoring in `reshape`:
* Replaced the inline size computation logic for `in_size` and `new_size` with calls to the new `core::size` utility, simplifying the implementation and improving maintainability.
* Updated the assertion logic in `reshape` to use `core::size` for comparing the sizes of the input and output extents, further reducing code duplication.