### PR TITLE
Hotfix simd friendly

### DIFF
--- a/ctmd/core/ctmd_core_broadcast.hpp
+++ b/ctmd/core/ctmd_core_broadcast.hpp
@@ -54,49 +54,6 @@ template <extents_c in1_t, extents_c in2_t, extents_c... ins_t>
 }
 
 template <extents_c in1_t, extents_c in2_t, extents_c... ins_t>
-[[nodiscard]] inline constexpr bool
-need_broadcast(const in1_t &in1 = in1_t{}, const in2_t &in2 = in2_t{},
-               const ins_t &...ins) noexcept {
-    if constexpr (in1_t::rank() != in2_t::rank()) {
-        return true;
-    }
-
-    for (size_t i = 0; i < in1_t::rank(); i++) {
-        if (in1.extent(i) != in2.extent(i)) {
-            return true;
-        }
-    }
-
-    if constexpr (sizeof...(ins_t) == 0) {
-        return false;
-
-    } else {
-        return need_broadcast(in2, ins...);
-    }
-}
-
-template <extents_c... ins_t>
-[[nodiscard]] inline constexpr bool
-need_broadcast(const std::tuple<ins_t...> &ins) noexcept {
-    constexpr size_t ins_num =
-        std::tuple_size_v<std::remove_reference_t<decltype(ins)>>;
-
-    static_assert(ins_num > 0, "broadcast requires at least one input.");
-
-    if constexpr (ins_num == 1) {
-        return false;
-
-    } else {
-        return std::apply(
-            [&](auto &&...ins_refs) {
-                return need_broadcast(
-                    std::forward<decltype(ins_refs)>(ins_refs)...);
-            },
-            ins);
-    }
-}
-
-template <extents_c in1_t, extents_c in2_t, extents_c... ins_t>
 [[nodiscard]] inline constexpr auto broadcast(const in1_t &in1 = in1_t{},
                                               const in2_t &in2 = in2_t{},
                                               const ins_t &...ins) noexcept {
@@ -244,8 +201,9 @@ make_submdspan_tuple(const std::tuple<ins_t...> &ins,
 
 template <size_t BatchRank, typename Func, mdspan_c... ins_t,
           typename... args_t>
-inline constexpr void batch_impl(Func &&func, const std::tuple<ins_t...> &ins,
-                                 const std::tuple<args_t...> &args) noexcept {
+inline constexpr void
+batch_impl_none(Func &&func, const std::tuple<ins_t...> &ins,
+                const std::tuple<args_t...> &args) noexcept {
     if constexpr (BatchRank == 0) {
         batch_call(std::forward<Func>(func), ins, args,
                    std::index_sequence_for<ins_t...>{},
@@ -256,8 +214,8 @@ inline constexpr void batch_impl(Func &&func, const std::tuple<ins_t...> &ins,
             typename std::tuple_element_t<0, std::tuple<ins_t...>>::index_type;
 
         for (index_type i = 0; i < std::get<0>(ins).extent(0); i++) {
-            batch_impl<BatchRank - 1>(std::forward<Func>(func),
-                                      make_submdspan_tuple(ins, i), args);
+            batch_impl_none<BatchRank - 1>(std::forward<Func>(func),
+                                           make_submdspan_tuple(ins, i), args);
         }
     }
 }
@@ -280,8 +238,8 @@ batch_impl_cpump(Func &&func, const std::tuple<ins_t...> &ins,
 
 #pragma omp parallel for
         for (index_type i = 0; i < std::get<0>(ins).extent(0); i++) {
-            batch_impl<BatchRank - 1>(std::forward<Func>(func),
-                                      make_submdspan_tuple(ins, i), args);
+            batch_impl_none<BatchRank - 1>(std::forward<Func>(func),
+                                           make_submdspan_tuple(ins, i), args);
         }
     }
 }
@@ -304,7 +262,7 @@ batch_impl_gpump(Func &&func, const std::tuple<ins_t...> &ins,
 
 #pragma omp target teams distribute parallel for
         for (index_type i = 0; i < std::get<0>(ins).extent(0); i++) {
-            batch_impl<BatchRank - 1>(std::forward<Func>(func),
+            batch_impl_none<BatchRank - 1>(std::forward<Func>(func),
                                       make_submdspan_tuple(ins, i), args);
         }
     }
@@ -313,6 +271,24 @@ batch_impl_gpump(Func &&func, const std::tuple<ins_t...> &ins,
 #endif
 
 #endif
+
+template <size_t BatchRank, typename Func, mdspan_c... ins_t,
+          typename... args_t>
+inline constexpr void batch_impl(Func &&func, const std::tuple<ins_t...> &ins,
+                                 const std::tuple<args_t...> &args,
+                                 const MPMode mpmode) noexcept {
+    if (mpmode == MPMode::CPUMP) [[unlikely]] {
+#ifdef _OPENMP
+        detail::batch_impl_cpump<BatchRank>(std::forward<Func>(func), ins,
+                                            args);
+        return;
+#else
+        assert(false);
+#endif
+    }
+
+    detail::batch_impl_none<BatchRank>(std::forward<Func>(func), ins, args);
+}
 
 template <typename T, extents_c exts_t>
 [[nodiscard]] inline constexpr auto create_out(const exts_t &exts) noexcept {
@@ -341,7 +317,7 @@ inline constexpr void batch(Func &&func, const std::tuple<ins_t...> &ins,
 
     if constexpr (!need_batch) {
         // Pass directly to the function
-        detail::batch_impl<0>(std::forward<Func>(func), ins, args);
+        detail::batch_impl_none<0>(std::forward<Func>(func), ins, args);
 
     } else {
         constexpr bool possibly_not_bcast = []<size_t... Is>(
@@ -358,29 +334,47 @@ inline constexpr void batch(Func &&func, const std::tuple<ins_t...> &ins,
         }(std::make_index_sequence<sizeof...(ins_t)>{});
 
         if constexpr (possibly_not_bcast) {
-            // Pass without broadcasting (simd friendly)
+            // Pass without broadcasting (less computation)
             constexpr size_t brank =
                 std::tuple_element_t<0, std::tuple<ins_t...>>::rank() -
                 std::tuple_element_t<0, std::tuple<uinexts_t...>>::rank();
 
-            const bool need_bcast = [&ins]<size_t... Is>(
+            const bool same_bexts = [&ins]<size_t... Is>(
                                         std::index_sequence<Is...>) {
-                return need_broadcast(std::make_tuple(
+                return same(std::make_tuple(
                     slice_from_start<brank>(std::get<Is>(ins).extents())...));
             }(std::make_index_sequence<sizeof...(ins_t)>{});
 
-            if (!need_bcast) [[likely]] {
-                if (mpmode == MPMode::CPUMP) [[unlikely]] {
-#ifdef _OPENMP
-                    detail::batch_impl_cpump<brank>(std::forward<Func>(func),
-                                                    ins, args);
-                    return;
-#else
-                    assert(false);
-#endif
+            if (same_bexts) [[likely]] {
+                const bool is_flattable =
+                    [&ins]<size_t... Is>(std::index_sequence<Is...>) {
+                        return (core::is_reshapable(std::get<Is>(ins)) && ...);
+                    }(std::make_index_sequence<sizeof...(ins_t)>{});
+
+                if (is_flattable) [[likely]] {
+                    // Flatten batch if possible (simd friendly)
+                    constexpr size_t static_bsize =
+                        static_size<decltype(slice_from_start<brank>(
+                            std::get<0>(ins).extents()))>();
+                    const size_t bsize = size(
+                        slice_from_start<brank>(std::get<0>(ins).extents()));
+
+                    const auto fins = [&ins, &uinexts, &bsize]<size_t... Is>(
+                                          std::index_sequence<Is...>) {
+                        return std::tuple{reshape(
+                            std::get<Is>(ins),
+                            concatenate(extents<size_t, static_bsize>{bsize},
+                                        std::get<Is>(uinexts)))...};
+                    }(std::make_index_sequence<sizeof...(ins_t)>{});
+
+                    detail::batch_impl<1>(std::forward<Func>(func), fins, args,
+                                          mpmode);
+
+                } else {
+                    detail::batch_impl<brank>(std::forward<Func>(func), ins,
+                                              args, mpmode);
                 }
 
-                detail::batch_impl<brank>(std::forward<Func>(func), ins, args);
                 return;
             }
         }
@@ -403,17 +397,7 @@ inline constexpr void batch(Func &&func, const std::tuple<ins_t...> &ins,
                              concatenate(bexts, std::get<Is>(uinexts)))...};
         }(std::make_index_sequence<sizeof...(ins_t)>{});
 
-        if (mpmode == MPMode::CPUMP) [[unlikely]] {
-#ifdef _OPENMP
-            detail::batch_impl_cpump<brank>(std::forward<Func>(func), bins,
-                                            args);
-            return;
-#else
-            assert(false);
-#endif
-        }
-
-        detail::batch_impl<brank>(std::forward<Func>(func), bins, args);
+        detail::batch_impl<brank>(std::forward<Func>(func), bins, args, mpmode);
     }
 }
 
@@ -424,17 +408,8 @@ template <typename Func, mdspan_c... ins_t, extents_c... uinexts_t,
 batch(Func &&func, const std::tuple<ins_t...> &ins,
       const std::tuple<uinexts_t...> &uinexts,
       const std::tuple<args_t...> &args, const MPMode mpmode) noexcept {
-    constexpr bool possibly_not_bcast = []<size_t... Is>(
-                                            std::index_sequence<Is...>) {
-        constexpr size_t ref =
-            std::tuple_element_t<0, std::tuple<ins_t...>>::rank() -
-            std::tuple_element_t<0, std::tuple<uinexts_t...>>::rank();
-        return (
-            (std::tuple_element_t<Is, std::tuple<ins_t...>>::rank() -
-                 std::tuple_element_t<Is, std::tuple<uinexts_t...>>::rank() ==
-             ref) &&
-            ...);
-    }(std::make_index_sequence<sizeof...(ins_t)>{});
+    // generate out
+    using element_t = std::common_type_t<element_type_t<ins_t>...>;
 
     const auto bexts = [&ins]<size_t... Is>(std::index_sequence<Is...>) {
         return broadcast(std::make_tuple(
@@ -444,60 +419,14 @@ batch(Func &&func, const std::tuple<ins_t...> &ins,
                 std::get<Is>(ins).extents())...));
     }(std::make_index_sequence<sizeof...(ins_t)>{});
 
-    constexpr size_t brank = decltype(bexts)::rank();
-
-    using element_t = std::common_type_t<element_type_t<ins_t>...>;
     auto out = detail::create_out<element_t>(
         core::concatenate(bexts, std::get<sizeof...(ins_t)>(uinexts)));
 
-    if constexpr (possibly_not_bcast) {
-        // Pass without broadcasting (simd friendly)
-        const bool need_bcast =
-            [&ins]<size_t... Is>(std::index_sequence<Is...>) {
-                return need_broadcast(std::make_tuple(
-                    slice_from_start<brank>(std::get<Is>(ins).extents())...));
-            }(std::make_index_sequence<sizeof...(ins_t)>{});
+    // batch
+    batch(std::forward<Func>(func),
+          std::tuple_cat(ins, std::make_tuple(to_mdspan(out))), uinexts, args,
+          mpmode);
 
-        if (!need_bcast) [[likely]] {
-            const auto bins = [&ins,
-                               &out]<size_t... Is>(std::index_sequence<Is...>) {
-                return std::tuple{std::get<Is>(ins)..., to_mdspan(out)};
-            }(std::make_index_sequence<sizeof...(ins_t)>{});
-
-            if (mpmode == MPMode::CPUMP) [[unlikely]] {
-#ifdef _OPENMP
-                detail::batch_impl_cpump<brank>(std::forward<Func>(func), bins,
-                                                args);
-                return out;
-#else
-                assert(false);
-#endif
-            }
-
-            detail::batch_impl<brank>(std::forward<Func>(func), bins, args);
-            return out;
-        }
-    }
-
-    // Broadcasting
-    const auto bins = [&ins, &uinexts, &bexts,
-                       &out]<size_t... Is>(std::index_sequence<Is...>) {
-        return std::tuple{
-            broadcast_to(std::get<Is>(ins),
-                         concatenate(bexts, std::get<Is>(uinexts)))...,
-            to_mdspan(out)};
-    }(std::make_index_sequence<sizeof...(ins_t)>{});
-
-    if (mpmode == MPMode::CPUMP) [[unlikely]] {
-#ifdef _OPENMP
-        detail::batch_impl_cpump<brank>(std::forward<Func>(func), bins, args);
-        return out;
-#else
-        assert(false);
-#endif
-    }
-
-    detail::batch_impl<brank>(std::forward<Func>(func), bins, args);
     return out;
 }
 
@@ -508,17 +437,8 @@ template <typename Func, mdspan_c... ins_t, extents_c... uinexts_t,
 batch(Func &&func, const std::tuple<ins_t...> &ins,
       const std::tuple<uinexts_t...> &uinexts,
       const std::tuple<args_t...> &args, const MPMode mpmode) noexcept {
-    constexpr bool possibly_not_bcast = []<size_t... Is>(
-                                            std::index_sequence<Is...>) {
-        constexpr size_t ref =
-            std::tuple_element_t<0, std::tuple<ins_t...>>::rank() -
-            std::tuple_element_t<0, std::tuple<uinexts_t...>>::rank();
-        return (
-            (std::tuple_element_t<Is, std::tuple<ins_t...>>::rank() -
-                 std::tuple_element_t<Is, std::tuple<uinexts_t...>>::rank() ==
-             ref) &&
-            ...);
-    }(std::make_index_sequence<sizeof...(ins_t)>{});
+    // generate out
+    using element_t = std::common_type_t<element_type_t<ins_t>...>;
 
     const auto bexts = [&ins]<size_t... Is>(std::index_sequence<Is...>) {
         return broadcast(std::make_tuple(
@@ -528,69 +448,20 @@ batch(Func &&func, const std::tuple<ins_t...> &ins,
                 std::get<Is>(ins).extents())...));
     }(std::make_index_sequence<sizeof...(ins_t)>{});
 
-    constexpr size_t brank = decltype(bexts)::rank();
-
-    using element_t = std::common_type_t<element_type_t<ins_t>...>;
     auto outs = [&uinexts, &bexts]<size_t... Is>(std::index_sequence<Is...>) {
         return std::tuple{detail::create_out<element_t>(core::concatenate(
             bexts, std::get<sizeof...(ins_t) + Is>(uinexts)))...};
     }(std::make_index_sequence<sizeof...(uinexts_t) - sizeof...(ins_t)>{});
 
-    if constexpr (possibly_not_bcast) {
-        // Pass without broadcasting (simd friendly)
-        const bool need_bcast =
-            [&ins]<size_t... Is>(std::index_sequence<Is...>) {
-                return need_broadcast(std::make_tuple(
-                    slice_from_start<brank>(std::get<Is>(ins).extents())...));
-            }(std::make_index_sequence<sizeof...(ins_t)>{});
+    // batch
+    [&func, &ins, &outs, &uinexts, &args,
+     &mpmode]<size_t... Is>(std::index_sequence<Is...>) {
+        batch(std::forward<Func>(func),
+              std::tuple_cat(ins,
+                             std::make_tuple(to_mdspan(std::get<Is>(outs))...)),
+              uinexts, args, mpmode);
+    }(std::make_index_sequence<std::tuple_size_v<decltype(outs)>>{});
 
-        if (!need_bcast) [[likely]] {
-            const auto bins = [&ins, &outs]<size_t... Is>(
-                                  std::index_sequence<Is...>) {
-                return [&ins, &outs]<size_t... Js>(std::index_sequence<Js...>) {
-                    return std::tuple{std::get<Is>(ins)...,
-                                      to_mdspan(std::get<Js>(outs))...};
-                }(std::make_index_sequence<
-                           std::tuple_size_v<decltype(outs)>>{});
-            }(std::make_index_sequence<sizeof...(ins_t)>{});
-
-            if (mpmode == MPMode::CPUMP) [[unlikely]] {
-#ifdef _OPENMP
-                detail::batch_impl_cpump<brank>(std::forward<Func>(func), bins,
-                                                args);
-                return outs;
-#else
-                assert(false);
-#endif
-            }
-
-            detail::batch_impl<brank>(std::forward<Func>(func), bins, args);
-            return outs;
-        }
-    }
-
-    // Broadcasting
-    const auto bins = [&ins, &uinexts, &bexts,
-                       &outs]<size_t... Is>(std::index_sequence<Is...>) {
-        return [&ins, &uinexts, &bexts,
-                &outs]<size_t... Js>(std::index_sequence<Js...>) {
-            return std::tuple{
-                broadcast_to(std::get<Is>(ins),
-                             concatenate(bexts, std::get<Is>(uinexts)))...,
-                to_mdspan(std::get<Js>(outs))...};
-        }(std::make_index_sequence<std::tuple_size_v<decltype(outs)>>{});
-    }(std::make_index_sequence<sizeof...(ins_t)>{});
-
-    if (mpmode == MPMode::CPUMP) [[unlikely]] {
-#ifdef _OPENMP
-        detail::batch_impl_cpump<brank>(std::forward<Func>(func), bins, args);
-        return outs;
-#else
-        assert(false);
-#endif
-    }
-
-    detail::batch_impl<brank>(std::forward<Func>(func), bins, args);
     return outs;
 }
 

--- a/ctmd/ctmd_all.hpp
+++ b/ctmd/ctmd_all.hpp
@@ -4,21 +4,21 @@
 
 namespace ctmd {
 
-template <typename in_t>
-[[nodiscard]] inline constexpr bool all(in_t &&in) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-    using rin_t = decltype(rin);
+template <typename InType>
+[[nodiscard]] inline constexpr bool all(InType &&In) noexcept {
+    const auto in = core::to_mdspan(std::forward<InType>(In));
+    using in_t = decltype(in);
 
-    if constexpr (!mdspan_c<rin_t>) {
+    if constexpr (!mdspan_c<in_t>) {
         return static_cast<bool>(in);
 
     } else {
-        if constexpr (rin_t::rank() == 0) {
-            return static_cast<bool>(rin());
+        if constexpr (in_t::rank() == 0) {
+            return static_cast<bool>(in());
 
         } else {
-            for (typename rin_t::size_type i = 0; i < rin.extent(0); i++) {
-                if (!all(core::submdspan_from_start(rin, i))) {
+            for (typename in_t::size_type i = 0; i < in.extent(0); i++) {
+                if (!all(core::submdspan_from_start(in, i))) {
                     return false;
                 }
             }

--- a/ctmd/ctmd_allclose.hpp
+++ b/ctmd/ctmd_allclose.hpp
@@ -5,13 +5,13 @@
 
 namespace ctmd {
 
-template <typename in1_t, typename in2_t>
+template <typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr bool
-allclose(in1_t &&in1, in2_t &&in2, const double rtol = 1e-05,
-         const double atol = 1e-08,
+allclose(In1Type &&In1, In2Type &&In2, const double &rtol = 1e-05,
+         const double &atol = 1e-08,
          const MPMode mpmode = MPMode::NONE) noexcept {
-    return ctmd::all(ctmd::isclose(std::forward<in1_t>(in1),
-                                   std::forward<in2_t>(in2), rtol, atol,
+    return ctmd::all(ctmd::isclose(std::forward<In1Type>(In1),
+                                   std::forward<In2Type>(In2), rtol, atol,
                                    mpmode));
 }
 

--- a/ctmd/ctmd_array_equal.hpp
+++ b/ctmd/ctmd_array_equal.hpp
@@ -4,31 +4,31 @@
 
 namespace ctmd {
 
-template <typename in1_t, typename in2_t>
-[[nodiscard]] inline constexpr bool array_equal(in1_t &&in1,
-                                                in2_t &&in2) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-    using rint1_t = decltype(rin1);
-    using rint2_t = decltype(rin2);
+template <typename In1Type, typename In2Type>
+[[nodiscard]] inline constexpr bool array_equal(In1Type &&In1,
+                                                In2Type &&In2) noexcept {
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
+    using in1_t = decltype(in1);
+    using in2_t = decltype(in2);
 
-    if constexpr (rint1_t::rank() != rint2_t::rank()) {
+    if constexpr (in1_t::rank() != in2_t::rank()) {
         return false;
     }
 
-    for (size_t i = 0; i < rint1_t::rank(); i++) {
-        if (rin1.extent(i) != rin2.extent(i)) {
+    for (size_t i = 0; i < in1_t::rank(); i++) {
+        if (in1.extent(i) != in2.extent(i)) {
             return false;
         }
     }
 
-    if constexpr (rint1_t::rank() == 0) {
-        return rin1() == rin2();
+    if constexpr (in1_t::rank() == 0) {
+        return in1() == in2();
 
     } else {
-        for (typename rint1_t::size_type i = 0; i < rin1.extent(0); i++) {
-            if (!array_equal(core::submdspan_from_start(rin1, i),
-                             core::submdspan_from_start(rin2, i))) {
+        for (typename in1_t::size_type i = 0; i < in1.extent(0); i++) {
+            if (!array_equal(core::submdspan_from_start(in1, i),
+                             core::submdspan_from_start(in2, i))) {
                 return false;
             }
         }

--- a/ctmd/ctmd_array_equiv.hpp
+++ b/ctmd/ctmd_array_equiv.hpp
@@ -5,12 +5,12 @@
 
 namespace ctmd {
 
-template <typename in1_t, typename in2_t>
+template <typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr bool
-array_equiv(in1_t &&in1, in2_t &&in2,
+array_equiv(In1Type &&In1, In2Type &&In2,
             const MPMode mpmode = MPMode::NONE) noexcept {
-    return ctmd::all(ctmd::equal(std::forward<in1_t>(in1),
-                                 std::forward<in2_t>(in2), mpmode));
+    return ctmd::all(ctmd::equal(std::forward<In1Type>(In1),
+                                 std::forward<In2Type>(In2), mpmode));
 }
 
 } // namespace ctmd

--- a/ctmd/ctmd_atan2.hpp
+++ b/ctmd/ctmd_atan2.hpp
@@ -19,41 +19,35 @@ inline constexpr void atan2_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename in1_t, typename in2_t, typename out_t>
-inline constexpr void atan2(in1_t &&in1, in2_t &&in2, out_t &&out,
+template <typename In1Type, typename In2Type, typename OutType>
+inline constexpr void atan2(In1Type &&In1, In2Type &&In2, OutType &&Out,
                             const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-    const auto rout = core::to_mdspan(std::forward<out_t>(out));
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
-    constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
-    constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rout)::index_type>{};
-
-    core::batch([](const auto &in1, const auto &in2,
-                   const auto &out) { detail::atan2_impl(in1, in2, out); },
-                std::tuple{rin1, rin2, rout},
-                std::tuple{urin1_exts, urin2_exts, urout_exts}, std::tuple{},
-                mpmode);
+    core::batch(
+        [](auto &&...elems) {
+            detail::atan2_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in1, in2, out},
+        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
 
-template <typename in1_t, typename in2_t>
+template <typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
-atan2(in1_t &&in1, in2_t &&in2, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-
-    constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
-    constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
-    constexpr auto urout_exts =
-        extents<std::common_type_t<typename decltype(rin1)::index_type,
-                                   typename decltype(rin2)::index_type>>{};
+atan2(In1Type &&In1, In2Type &&In2,
+      const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
 
     return core::batch(
-        [](const auto &in1, const auto &in2, const auto &out) {
-            detail::atan2_impl(in1, in2, out);
+        [](auto &&...elems) {
+            detail::atan2_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{rin1, rin2}, std::tuple{urin1_exts, urin2_exts, urout_exts},
+        std::tuple{in1, in2},
+        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
         std::tuple{}, mpmode);
 }
 

--- a/ctmd/ctmd_copy.hpp
+++ b/ctmd/ctmd_copy.hpp
@@ -13,33 +13,31 @@ inline constexpr void copy_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename in_t, typename out_t>
-inline constexpr void copy(in_t &&in, out_t &&out,
+template <typename InType, typename OutType>
+inline constexpr void copy(InType &&In, OutType &&Out,
                            const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-    const auto rout = core::to_mdspan(std::forward<out_t>(out));
-
-    constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rout)::index_type>{};
+    const auto in = core::to_mdspan(std::forward<InType>(In));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
     core::batch(
-        [](const auto &in, const auto &out) { detail::copy_impl(in, out); },
-        std::tuple{rin, rout}, std::tuple{urin_exts, urout_exts}, std::tuple{},
-        mpmode);
+        [](auto &&...elems) {
+            detail::copy_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
 
-template <typename in_t>
+template <typename InType>
 [[nodiscard]] inline constexpr auto
-copy(in_t &&in, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-
-    constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rin)::index_type>{};
+copy(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in = core::to_mdspan(std::forward<InType>(In));
 
     return core::batch(
-        [](const auto &in, const auto &out) { detail::copy_impl(in, out); },
-        std::tuple{rin}, std::tuple{urin_exts, urout_exts}, std::tuple{},
-        mpmode);
+        [](auto &&...elems) {
+            detail::copy_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/ctmd_cos.hpp
+++ b/ctmd/ctmd_cos.hpp
@@ -15,33 +15,31 @@ inline constexpr void cos_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename in_t, typename out_t>
-inline constexpr void cos(in_t &&in, out_t &&out,
+template <typename InType, typename OutType>
+inline constexpr void cos(InType &&In, OutType &&Out,
                           const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-    const auto rout = core::to_mdspan(std::forward<out_t>(out));
-
-    constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rout)::index_type>{};
+    const auto in = core::to_mdspan(std::forward<InType>(In));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
     core::batch(
-        [](const auto &in, const auto &out) { detail::cos_impl(in, out); },
-        std::tuple{rin, rout}, std::tuple{urin_exts, urout_exts}, std::tuple{},
-        mpmode);
+        [](auto &&...elems) {
+            detail::cos_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
 
-template <typename in_t>
+template <typename InType>
 [[nodiscard]] inline constexpr auto
-cos(in_t &&in, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-
-    constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rin)::index_type>{};
+cos(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in = core::to_mdspan(std::forward<InType>(In));
 
     return core::batch(
-        [](const auto &in, const auto &out) { detail::cos_impl(in, out); },
-        std::tuple{rin}, std::tuple{urin_exts, urout_exts}, std::tuple{},
-        mpmode);
+        [](auto &&...elems) {
+            detail::cos_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/ctmd_divide.hpp
+++ b/ctmd/ctmd_divide.hpp
@@ -14,41 +14,35 @@ inline constexpr void divide_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename in1_t, typename in2_t, typename out_t>
-inline constexpr void divide(in1_t &&in1, in2_t &&in2, out_t &&out,
+template <typename In1Type, typename In2Type, typename OutType>
+inline constexpr void divide(In1Type &&In1, In2Type &&In2, OutType &&Out,
                              const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-    const auto rout = core::to_mdspan(std::forward<out_t>(out));
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
-    constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
-    constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rout)::index_type>{};
-
-    core::batch([](const auto &in1, const auto &in2,
-                   const auto &out) { detail::divide_impl(in1, in2, out); },
-                std::tuple{rin1, rin2, rout},
-                std::tuple{urin1_exts, urin2_exts, urout_exts}, std::tuple{},
-                mpmode);
+    core::batch(
+        [](auto &&...elems) {
+            detail::divide_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in1, in2, out},
+        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
 
-template <typename in1_t, typename in2_t>
+template <typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
-divide(in1_t &&in1, in2_t &&in2, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-
-    constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
-    constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
-    constexpr auto urout_exts =
-        extents<std::common_type_t<typename decltype(rin1)::index_type,
-                                   typename decltype(rin2)::index_type>>{};
+divide(In1Type &&In1, In2Type &&In2,
+       const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
 
     return core::batch(
-        [](const auto &in1, const auto &in2, const auto &out) {
-            detail::divide_impl(in1, in2, out);
+        [](auto &&...elems) {
+            detail::divide_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{rin1, rin2}, std::tuple{urin1_exts, urin2_exts, urout_exts},
+        std::tuple{in1, in2},
+        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
         std::tuple{}, mpmode);
 }
 

--- a/ctmd/ctmd_equal.hpp
+++ b/ctmd/ctmd_equal.hpp
@@ -14,42 +14,35 @@ inline constexpr void equal_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename in1_t, typename in2_t, typename out_t>
-inline constexpr void equal(in1_t &&in1, in2_t &&in2, out_t &&out,
+template <typename In1Type, typename In2Type, typename OutType>
+inline constexpr void equal(In1Type &&In1, In2Type &&In2, OutType &&Out,
                             const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-    const auto rout = core::to_mdspan(std::forward<out_t>(out));
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
-    constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
-    constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rout)::index_type>{};
-
-    core::batch([](const auto &in1, const auto &in2,
-                   const auto &out) { detail::equal_impl(in1, in2, out); },
-                std::tuple{rin1, rin2, rout},
-                std::tuple{urin1_exts, urin2_exts, urout_exts}, std::tuple{},
-                mpmode);
+    core::batch(
+        [](auto &&...elems) {
+            detail::equal_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in1, in2, out},
+        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
 
-template <typename in1_t, typename in2_t, arithmetic_c rtol_t = double,
-          arithmetic_c atol_t = double>
+template <typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
-equal(in1_t &&in1, in2_t &&in2, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-
-    constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
-    constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
-    constexpr auto urout_exts =
-        extents<std::common_type_t<typename decltype(rin1)::index_type,
-                                   typename decltype(rin2)::index_type>>{};
+equal(In1Type &&In1, In2Type &&In2,
+      const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
 
     return core::batch(
-        [](const auto &in1, const auto &in2, const auto &out) {
-            detail::equal_impl(in1, in2, out);
+        [](auto &&...elems) {
+            detail::equal_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{rin1, rin2}, std::tuple{urin1_exts, urin2_exts, urout_exts},
+        std::tuple{in1, in2},
+        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
         std::tuple{}, mpmode);
 }
 

--- a/ctmd/ctmd_fill.hpp
+++ b/ctmd/ctmd_fill.hpp
@@ -13,16 +13,17 @@ inline constexpr void fill_impl(const in_t &in, const val_t &val) noexcept {
 
 } // namespace detail
 
-template <typename in_t, arithmetic_c val_t>
-inline constexpr void fill(in_t &&in, const val_t &val,
+template <typename InType, arithmetic_c val_t>
+inline constexpr void fill(InType &&In, const val_t &val,
                            const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-
-    constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
+    const auto in = core::to_mdspan(std::forward<InType>(In));
 
     core::batch(
-        [](const auto &in, const auto &val) { detail::fill_impl(in, val); },
-        std::tuple{rin}, std::tuple{urin_exts}, std::tuple{val}, mpmode);
+        [](auto &&...elems) {
+            detail::fill_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in}, std::tuple{extents<uint8_t>{}}, std::tuple{val},
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/ctmd_isclose.hpp
+++ b/ctmd/ctmd_isclose.hpp
@@ -5,63 +5,50 @@
 namespace ctmd {
 namespace detail {
 
-template <mdspan_c in1_t, mdspan_c in2_t, mdspan_c out_t,
-          arithmetic_c rtol_t = double, arithmetic_c atol_t = double>
+template <mdspan_c in1_t, mdspan_c in2_t, mdspan_c out_t>
     requires(in1_t::rank() == 0 && in2_t::rank() == 0 && out_t::rank() == 0)
 inline constexpr void isclose_impl(const in1_t &in1, const in2_t &in2,
-                                   const out_t &out, const rtol_t &rtol,
-                                   const atol_t &atol) noexcept {
-    out() = std::abs(in1() - in2()) <= (atol + rtol * std::abs(in2()));
+                                   const out_t &out, const double &rtol,
+                                   const double &atol) noexcept {
+    using T = std::remove_cvref_t<decltype(in2())>;
+    out() = std::abs(in1() - in2()) <= ((T)atol + (T)rtol * std::abs(in2()));
 }
 
 } // namespace detail
 
-template <typename in1_t, typename in2_t, typename out_t,
-          arithmetic_c rtol_t = double, arithmetic_c atol_t = double>
-    requires(!arithmetic_c<out_t>)
-inline constexpr void isclose(in1_t &&in1, in2_t &&in2, out_t &&out,
-                              const rtol_t &rtol = 1e-05,
-                              const atol_t &atol = 1e-08,
+template <typename In1Type, typename In2Type, typename OutType>
+    requires(!arithmetic_c<OutType>)
+inline constexpr void isclose(In1Type &&In1, In2Type &&In2, OutType &&Out,
+                              const double &rtol = 1e-05,
+                              const double &atol = 1e-08,
                               const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-    const auto rout = core::to_mdspan(std::forward<out_t>(out));
-
-    constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
-    constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rout)::index_type>{};
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
     core::batch(
-        [](const auto &in1, const auto &in2, const auto &out, const auto &rtol,
-           const auto &atol) {
-            detail::isclose_impl(in1, in2, out, rtol, atol);
+        [](auto &&...elems) {
+            detail::isclose_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{rin1, rin2, rout},
-        std::tuple{urin1_exts, urin2_exts, urout_exts}, std::tuple{rtol, atol},
-        mpmode);
+        std::tuple{in1, in2, out},
+        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{rtol, atol}, mpmode);
 }
 
-template <typename in1_t, typename in2_t, arithmetic_c rtol_t = double,
-          arithmetic_c atol_t = double>
+template <typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
-isclose(in1_t &&in1, in2_t &&in2, const rtol_t &rtol = 1e-05,
-        const atol_t &atol = 1e-08,
+isclose(In1Type &&In1, In2Type &&In2, const double &rtol = 1e-05,
+        const double &atol = 1e-08,
         const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-
-    constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
-    constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
-    constexpr auto urout_exts =
-        extents<std::common_type_t<typename decltype(rin1)::index_type,
-                                   typename decltype(rin2)::index_type>>{};
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
 
     return core::batch(
-        [](const auto &in1, const auto &in2, const auto &out, const auto &rtol,
-           const auto &atol) {
-            detail::isclose_impl(in1, in2, out, rtol, atol);
+        [](auto &&...elems) {
+            detail::isclose_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{rin1, rin2}, std::tuple{urin1_exts, urin2_exts, urout_exts},
+        std::tuple{in1, in2},
+        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
         std::tuple{rtol, atol}, mpmode);
 }
 

--- a/ctmd/ctmd_matmul.hpp
+++ b/ctmd/ctmd_matmul.hpp
@@ -4,18 +4,19 @@
 
 namespace ctmd {
 
-template <typename in1_t, typename in2_t, typename out_t>
-inline constexpr void matmul(in1_t &&in1, in2_t &&in2, out_t &&out,
+template <typename In1Type, typename In2Type, typename OutType>
+inline constexpr void matmul(In1Type &&In1, In2Type &&In2, OutType &&Out,
                              const MPMode mpmode = MPMode::NONE) noexcept {
-    linalg::matmul(std::forward<in1_t>(in1), std::forward<in2_t>(in2),
-                   std::forward<out_t>(out), mpmode);
+    linalg::matmul(std::forward<In1Type>(In1), std::forward<In2Type>(In2),
+                   std::forward<OutType>(Out), mpmode);
 }
 
-template <typename in1_t, typename in2_t>
+template <typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
-matmul(in1_t &&in1, in2_t &&in2, const MPMode mpmode = MPMode::NONE) noexcept {
-    return linalg::matmul(std::forward<in1_t>(in1), std::forward<in2_t>(in2),
-                          mpmode);
+matmul(In1Type &&In1, In2Type &&In2,
+       const MPMode mpmode = MPMode::NONE) noexcept {
+    return linalg::matmul(std::forward<In1Type>(In1),
+                          std::forward<In2Type>(In2), mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/ctmd_matvec.hpp
+++ b/ctmd/ctmd_matvec.hpp
@@ -4,18 +4,19 @@
 
 namespace ctmd {
 
-template <typename in1_t, typename in2_t, typename out_t>
-inline constexpr void matvec(in1_t &&in1, in2_t &&in2, out_t &&out,
+template <typename In1Type, typename In2Type, typename OutType>
+inline constexpr void matvec(In1Type &&In1, In2Type &&In2, OutType &&Out,
                              const MPMode mpmode = MPMode::NONE) noexcept {
-    linalg::matvec(std::forward<in1_t>(in1), std::forward<in2_t>(in2),
-                   std::forward<out_t>(out), mpmode);
+    linalg::matvec(std::forward<In1Type>(In1), std::forward<In2Type>(In2),
+                   std::forward<OutType>(Out), mpmode);
 }
 
-template <typename in1_t, typename in2_t>
+template <typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
-matvec(in1_t &&in1, in2_t &&in2, const MPMode mpmode = MPMode::NONE) noexcept {
-    return linalg::matvec(std::forward<in1_t>(in1), std::forward<in2_t>(in2),
-                          mpmode);
+matvec(In1Type &&In1, In2Type &&In2,
+       const MPMode mpmode = MPMode::NONE) noexcept {
+    return linalg::matvec(std::forward<In1Type>(In1),
+                          std::forward<In2Type>(In2), mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/ctmd_multiply.hpp
+++ b/ctmd/ctmd_multiply.hpp
@@ -14,42 +14,35 @@ inline constexpr void multiply_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename in1_t, typename in2_t, typename out_t>
-inline constexpr void multiply(in1_t &&in1, in2_t &&in2, out_t &&out,
+template <typename In1Type, typename In2Type, typename OutType>
+inline constexpr void multiply(In1Type &&In1, In2Type &&In2, OutType &&Out,
                                const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-    const auto rout = core::to_mdspan(std::forward<out_t>(out));
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
-    constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
-    constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rout)::index_type>{};
-
-    core::batch([](const auto &in1, const auto &in2,
-                   const auto &out) { detail::multiply_impl(in1, in2, out); },
-                std::tuple{rin1, rin2, rout},
-                std::tuple{urin1_exts, urin2_exts, urout_exts}, std::tuple{},
-                mpmode);
+    core::batch(
+        [](auto &&...elems) {
+            detail::multiply_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in1, in2, out},
+        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
 
-template <typename in1_t, typename in2_t>
+template <typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
-multiply(in1_t &&in1, in2_t &&in2,
+multiply(In1Type &&In1, In2Type &&In2,
          const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-
-    constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
-    constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
-    constexpr auto urout_exts =
-        extents<std::common_type_t<typename decltype(rin1)::index_type,
-                                   typename decltype(rin2)::index_type>>{};
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
 
     return core::batch(
-        [](const auto &in1, const auto &in2, const auto &out) {
-            detail::multiply_impl(in1, in2, out);
+        [](auto &&...elems) {
+            detail::multiply_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{rin1, rin2}, std::tuple{urin1_exts, urin2_exts, urout_exts},
+        std::tuple{in1, in2},
+        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
         std::tuple{}, mpmode);
 }
 

--- a/ctmd/ctmd_negative.hpp
+++ b/ctmd/ctmd_negative.hpp
@@ -13,33 +13,31 @@ inline constexpr void negative_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename in_t, typename out_t>
-inline constexpr void negative(in_t &&in, out_t &&out,
+template <typename InType, typename OutType>
+inline constexpr void negative(InType &&In, OutType &&Out,
                                const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-    const auto rout = core::to_mdspan(std::forward<out_t>(out));
-
-    constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rout)::index_type>{};
+    const auto in = core::to_mdspan(std::forward<InType>(In));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
     core::batch(
-        [](const auto &in, const auto &out) { detail::negative_impl(in, out); },
-        std::tuple{rin, rout}, std::tuple{urin_exts, urout_exts}, std::tuple{},
-        mpmode);
+        [](auto &&...elems) {
+            detail::negative_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
 
-template <typename in_t>
+template <typename InType>
 [[nodiscard]] inline constexpr auto
-negative(in_t &&in, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-
-    constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rin)::index_type>{};
+negative(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in = core::to_mdspan(std::forward<InType>(In));
 
     return core::batch(
-        [](const auto &in, const auto &out) { detail::negative_impl(in, out); },
-        std::tuple{rin}, std::tuple{urin_exts, urout_exts}, std::tuple{},
-        mpmode);
+        [](auto &&...elems) {
+            detail::negative_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/ctmd_not_equal.hpp
+++ b/ctmd/ctmd_not_equal.hpp
@@ -14,42 +14,35 @@ inline constexpr void not_equal_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename in1_t, typename in2_t, typename out_t>
-inline constexpr void not_equal(in1_t &&in1, in2_t &&in2, out_t &&out,
+template <typename In1Type, typename In2Type, typename OutType>
+inline constexpr void not_equal(In1Type &&In1, In2Type &&In2, OutType &&Out,
                                 const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-    const auto rout = core::to_mdspan(std::forward<out_t>(out));
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
-    constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
-    constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rout)::index_type>{};
-
-    core::batch([](const auto &in1, const auto &in2,
-                   const auto &out) { detail::not_equal_impl(in1, in2, out); },
-                std::tuple{rin1, rin2, rout},
-                std::tuple{urin1_exts, urin2_exts, urout_exts}, std::tuple{},
-                mpmode);
+    core::batch(
+        [](auto &&...elems) {
+            detail::not_equal_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in1, in2, out},
+        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
 
-template <typename in1_t, typename in2_t>
+template <typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
-not_equal(in1_t &&in1, in2_t &&in2,
+not_equal(In1Type &&In1, In2Type &&In2,
           const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-
-    constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
-    constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
-    constexpr auto urout_exts =
-        extents<std::common_type_t<typename decltype(rin1)::index_type,
-                                   typename decltype(rin2)::index_type>>{};
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
 
     return core::batch(
-        [](const auto &in1, const auto &in2, const auto &out) {
-            detail::not_equal_impl(in1, in2, out);
+        [](auto &&...elems) {
+            detail::not_equal_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{rin1, rin2}, std::tuple{urin1_exts, urin2_exts, urout_exts},
+        std::tuple{in1, in2},
+        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
         std::tuple{}, mpmode);
 }
 

--- a/ctmd/ctmd_reshape.hpp
+++ b/ctmd/ctmd_reshape.hpp
@@ -7,42 +7,8 @@ namespace ctmd {
 template <typename InType, extents_c extents_t>
 [[nodiscard]] inline constexpr auto
 reshape(InType &&In, const extents_t &new_extents = extents_t{}) noexcept {
-    const auto in = core::to_mdspan(std::forward<InType>(In));
-    using in_t = decltype(in);
-
-    if constexpr (in_t::is_always_unique() && in_t::is_always_exhaustive() &&
-                  in_t::is_always_strided() && in_t::rank_dynamic() == 0 &&
-                  extents_t::rank_dynamic() == 0) {
-        constexpr size_t in_size =
-            []<size_t... Is>(std::index_sequence<Is...>) {
-                return ((in_t::static_extent(Is) * ...));
-            }(std::make_index_sequence<in_t::rank()>{});
-        constexpr size_t new_size =
-            []<size_t... Is>(std::index_sequence<Is...>) {
-                return ((extents_t::static_extent(Is) * ...));
-            }(std::make_index_sequence<extents_t::rank()>{});
-
-        static_assert(in_size == new_size,
-                      "The number of elements in the input and output "
-                      "mdspan must be the same.");
-
-        return mdspan<typename in_t::element_type, extents_t>{in.data_handle(),
-                                                              new_extents};
-
-    } else {
-        assert(in.is_unique());
-        assert(in.is_exhaustive());
-        assert(in.is_strided());
-        assert([&in]<size_t... Is>(std::index_sequence<Is...>) {
-            return ((in.extent(Is) * ...));
-        }(std::make_index_sequence<in_t::rank()>{}) ==
-               [&new_extents]<size_t... Is>(std::index_sequence<Is...>) {
-                   return ((new_extents.extent(Is) * ...));
-               }(std::make_index_sequence<extents_t::rank()>{}));
-
-        return mdspan<typename in_t::element_type, extents_t>{in.data_handle(),
-                                                              new_extents};
-    }
+    return core::reshape(core::to_mdspan(std::forward<InType>(In)),
+                         new_extents);
 }
 
 } // namespace ctmd

--- a/ctmd/ctmd_sin.hpp
+++ b/ctmd/ctmd_sin.hpp
@@ -15,33 +15,30 @@ inline constexpr void sin_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename in_t, typename out_t>
-inline constexpr void sin(in_t &&in, out_t &&out,
+template <typename InType, typename OutType>
+inline constexpr void sin(InType &&In, OutType &&Out,
                           const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-    const auto rout = core::to_mdspan(std::forward<out_t>(out));
-
-    constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rout)::index_type>{};
+    const auto in = core::to_mdspan(std::forward<InType>(In));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
     core::batch(
-        [](const auto &in, const auto &out) { detail::sin_impl(in, out); },
-        std::tuple{rin, rout}, std::tuple{urin_exts, urout_exts}, std::tuple{},
-        mpmode);
+        [](auto &&...elems) {
+            detail::sin_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
 
-template <typename in_t>
+template <typename InType>
 [[nodiscard]] inline constexpr auto
-sin(in_t &&in, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-
-    constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rin)::index_type>{};
+sin(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in = core::to_mdspan(std::forward<InType>(In));
 
     return core::batch(
-        [](const auto &in, const auto &out) { detail::sin_impl(in, out); },
-        std::tuple{rin}, std::tuple{urin_exts, urout_exts}, std::tuple{},
-        mpmode);
+        [](auto &&...elems) {
+            detail::sin_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
-
 } // namespace ctmd

--- a/ctmd/ctmd_sqrt.hpp
+++ b/ctmd/ctmd_sqrt.hpp
@@ -15,33 +15,31 @@ inline constexpr void sqrt_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename in_t, typename out_t>
-inline constexpr void sqrt(in_t &&in, out_t &&out,
+template <typename InType, typename OutType>
+inline constexpr void sqrt(InType &&In, OutType &&Out,
                            const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-    const auto rout = core::to_mdspan(std::forward<out_t>(out));
-
-    constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rout)::index_type>{};
+    const auto in = core::to_mdspan(std::forward<InType>(In));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
     core::batch(
-        [](const auto &in, const auto &out) { detail::sqrt_impl(in, out); },
-        std::tuple{rin, rout}, std::tuple{urin_exts, urout_exts}, std::tuple{},
-        mpmode);
+        [](auto &&...elems) {
+            detail::sqrt_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
 
-template <typename in_t>
+template <typename InType>
 [[nodiscard]] inline constexpr auto
-sqrt(in_t &&in, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-
-    constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rin)::index_type>{};
+sqrt(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in = core::to_mdspan(std::forward<InType>(In));
 
     return core::batch(
-        [](const auto &in, const auto &out) { detail::sqrt_impl(in, out); },
-        std::tuple{rin}, std::tuple{urin_exts, urout_exts}, std::tuple{},
-        mpmode);
+        [](auto &&...elems) {
+            detail::sqrt_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/ctmd_subtract.hpp
+++ b/ctmd/ctmd_subtract.hpp
@@ -14,42 +14,36 @@ inline constexpr void subtract_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename in1_t, typename in2_t, typename out_t>
-inline constexpr void subtract(in1_t &&in1, in2_t &&in2, out_t &&out,
+template <typename In1Type, typename In2Type, typename OutType>
+inline constexpr void subtract(In1Type &&In1, In2Type &&In2, OutType &&Out,
                                const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-    const auto rout = core::to_mdspan(std::forward<out_t>(out));
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
-    constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
-    constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rout)::index_type>{};
-
-    core::batch([](const auto &in1, const auto &in2,
-                   const auto &out) { detail::subtract_impl(in1, in2, out); },
-                std::tuple{rin1, rin2, rout},
-                std::tuple{urin1_exts, urin2_exts, urout_exts}, std::tuple{},
-                mpmode);
-}
-
-template <typename in1_t, typename in2_t>
-[[nodiscard]] inline constexpr auto
-subtract(in1_t &&in1, in2_t &&in2,
-         const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-
-    constexpr auto urin1_exts = extents<typename decltype(rin1)::index_type>{};
-    constexpr auto urin2_exts = extents<typename decltype(rin2)::index_type>{};
-    constexpr auto urout_exts =
-        extents<std::common_type_t<typename decltype(rin1)::index_type,
-                                   typename decltype(rin2)::index_type>>{};
-
-    return core::batch(
-        [](const auto &in1, const auto &in2, const auto &out) {
-            detail::subtract_impl(in1, in2, out);
+    core::batch(
+        [](auto &&...elems) {
+            detail::subtract_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{rin1, rin2}, std::tuple{urin1_exts, urin2_exts, urout_exts},
+        std::tuple{in1, in2, out},
+        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
         std::tuple{}, mpmode);
 }
+
+template <typename In1Type, typename In2Type>
+[[nodiscard]] inline constexpr auto
+subtract(In1Type &&In1, In2Type &&In2,
+         const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
+
+    return core::batch(
+        [](auto &&...elems) {
+            detail::subtract_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in1, in2},
+        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
+}
+
 } // namespace ctmd

--- a/ctmd/ctmd_tan.hpp
+++ b/ctmd/ctmd_tan.hpp
@@ -15,33 +15,31 @@ inline constexpr void tan_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename in_t, typename out_t>
-inline constexpr void tan(in_t &&in, out_t &&out,
+template <typename InType, typename OutType>
+inline constexpr void tan(InType &&In, OutType &&Out,
                           const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-    const auto rout = core::to_mdspan(std::forward<out_t>(out));
-
-    constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rout)::index_type>{};
+    const auto in = core::to_mdspan(std::forward<InType>(In));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
     core::batch(
-        [](const auto &in, const auto &out) { detail::tan_impl(in, out); },
-        std::tuple{rin, rout}, std::tuple{urin_exts, urout_exts}, std::tuple{},
-        mpmode);
+        [](auto &&...elems) {
+            detail::tan_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
 
-template <typename in_t>
+template <typename InType>
 [[nodiscard]] inline constexpr auto
-tan(in_t &&in, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-
-    constexpr auto urin_exts = extents<typename decltype(rin)::index_type>{};
-    constexpr auto urout_exts = extents<typename decltype(rin)::index_type>{};
+tan(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in = core::to_mdspan(std::forward<InType>(In));
 
     return core::batch(
-        [](const auto &in, const auto &out) { detail::tan_impl(in, out); },
-        std::tuple{rin}, std::tuple{urin_exts, urout_exts}, std::tuple{},
-        mpmode);
+        [](auto &&...elems) {
+            detail::tan_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/ctmd_vecmat.hpp
+++ b/ctmd/ctmd_vecmat.hpp
@@ -4,18 +4,19 @@
 
 namespace ctmd {
 
-template <typename in1_t, typename in2_t, typename out_t>
-inline constexpr void vecmat(in1_t &&in1, in2_t &&in2, out_t &&out,
+template <typename In1Type, typename In2Type, typename OutType>
+inline constexpr void vecmat(In1Type &&In1, In2Type &&In2, OutType &&Out,
                              const MPMode mpmode = MPMode::NONE) noexcept {
-    linalg::vecmat(std::forward<in1_t>(in1), std::forward<in2_t>(in2),
-                   std::forward<out_t>(out), mpmode);
+    linalg::vecmat(std::forward<In1Type>(In1), std::forward<In2Type>(In2),
+                   std::forward<OutType>(Out), mpmode);
 }
 
-template <typename in1_t, typename in2_t>
+template <typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
-vecmat(in1_t &&in1, in2_t &&in2, const MPMode mpmode = MPMode::NONE) noexcept {
-    return linalg::vecmat(std::forward<in1_t>(in1), std::forward<in2_t>(in2),
-                          mpmode);
+vecmat(In1Type &&In1, In2Type &&In2,
+       const MPMode mpmode = MPMode::NONE) noexcept {
+    return linalg::vecmat(std::forward<In1Type>(In1),
+                          std::forward<In2Type>(In2), mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/linalg/ctmd_linalg_inv.hpp
+++ b/ctmd/linalg/ctmd_linalg_inv.hpp
@@ -11,39 +11,39 @@ namespace detail {
 template <mdspan_c in_t, mdspan_c out_t>
     requires(in_t::rank() == 2 && out_t::rank() == 2)
 inline constexpr void inv_naive(const in_t &in, const out_t &out) noexcept {
-    using TO = typename out_t::element_type;
+    using index_type = typename in_t::index_type;
 
-    const size_t n = in.extent(0);
+    const index_type n = in.extent(0);
 
     // check in and out are same pointer
     auto in_copy = copy(in);
-    for (size_t i = 0; i < n; i++) {
-        for (size_t j = 0; j < n; j++) {
+    for (index_type i = 0; i < n; i++) {
+        for (index_type j = 0; j < n; j++) {
             out(i, j) = (i == j) ? 1 : 0;
         }
     }
 
-    for (size_t i = 0; i < n; i++) {
-        const TO pivot = in_copy(i, i);
+    for (index_type i = 0; i < n; i++) {
+        const auto pivot = in_copy(i, i);
 
-        if (pivot == TO(0)) {
+        if (pivot == 0) {
             // Handle error: singular matrix (no inverse)
             return;
         }
 
         // Normalize the pivot row
-        for (size_t j = 0; j < n; j++) {
+        for (index_type j = 0; j < n; j++) {
             in_copy(i, j) /= pivot;
             out(i, j) /= pivot;
         }
 
         // Eliminate other rows
-        for (size_t j = 0; j < n; j++) {
+        for (index_type j = 0; j < n; j++) {
             if (i == j)
                 continue;
 
-            TO factor = in_copy(j, i);
-            for (size_t k = 0; k < n; k++) {
+            const auto factor = in_copy(j, i);
+            for (index_type k = 0; k < n; k++) {
                 in_copy(j, k) -= factor * in_copy(i, k);
                 out(j, k) -= factor * out(i, k);
             }
@@ -72,33 +72,35 @@ inline constexpr void inv_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename in_t, typename out_t>
-inline constexpr void inv(in_t &&in, out_t &&out,
+template <typename InType, typename OutType>
+inline constexpr void inv(InType &&In, OutType &&Out,
                           const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-    const auto rout = core::to_mdspan(std::forward<out_t>(out));
-
-    const auto urin_exts = core::slice_from_last<2>(rin.extents());
-    const auto urout_exts = core::slice_from_last<2>(rout.extents());
+    const auto in = core::to_mdspan(std::forward<InType>(In));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
     core::batch(
-        [](const auto &in, const auto &out) { detail::inv_impl(in, out); },
-        std::tuple{rin, rout}, std::tuple{urin_exts, urout_exts}, std::tuple{},
-        mpmode);
+        [](auto &&...elems) {
+            detail::inv_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in, out},
+        std::tuple{core::slice_from_last<2>(in.extents()),
+                   core::slice_from_last<2>(out.extents())},
+        std::tuple{}, mpmode);
 }
 
-template <typename in_t>
+template <typename InType>
 [[nodiscard]] inline constexpr auto
-inv(in_t &&in, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin = core::to_mdspan(std::forward<in_t>(in));
-
-    const auto urin_exts = core::slice_from_last<2>(rin.extents());
-    const auto urout_exts = urin_exts;
+inv(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in = core::to_mdspan(std::forward<InType>(In));
 
     return core::batch(
-        [](const auto &in, const auto &out) { detail::inv_impl(in, out); },
-        std::tuple{rin}, std::tuple{urin_exts, urout_exts}, std::tuple{},
-        mpmode);
+        [](auto &&...elems) {
+            detail::inv_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in},
+        std::tuple{core::slice_from_last<2>(in.extents()),
+                   core::slice_from_last<2>(in.extents())},
+        std::tuple{}, mpmode);
 }
 
 } // namespace linalg

--- a/ctmd/linalg/ctmd_linalg_matmul.hpp
+++ b/ctmd/linalg/ctmd_linalg_matmul.hpp
@@ -15,10 +15,10 @@ inline constexpr void matmul_naive(const in1_t &in1, const in2_t &in2,
             core::to_mdspan(out).data_handle() &&
         core::to_mdspan(in2).data_handle() !=
             core::to_mdspan(out).data_handle()) [[likely]] {
-        for (typename out_t::size_type i = 0; i < out.extent(0); i++) {
-            for (typename out_t::size_type j = 0; j < out.extent(1); j++) {
+        for (typename out_t::index_type i = 0; i < out.extent(0); i++) {
+            for (typename out_t::index_type j = 0; j < out.extent(1); j++) {
                 out(i, j) = 0;
-                for (typename in1_t::size_type k = 0; k < in1.extent(1); k++) {
+                for (typename in1_t::index_type k = 0; k < in1.extent(1); k++) {
                     out(i, j) += in1(i, k) * in2(k, j);
                 }
             }
@@ -58,44 +58,45 @@ inline constexpr void matmul_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename in1_t, typename in2_t, typename out_t>
-inline constexpr void matmul(in1_t &&in1, in2_t &&in2, out_t &&out,
+template <typename In1Type, typename In2Type, typename OutType>
+inline constexpr void matmul(In1Type &&In1, In2Type &&In2, OutType &&Out,
                              const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-    const auto rout = core::to_mdspan(std::forward<out_t>(out));
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
-    const auto urin1_exts = core::slice_from_last<2>(rin1.extents());
-    const auto urin2_exts = core::slice_from_last<2>(rin2.extents());
-    const auto urout_exts = core::slice_from_last<2>(rout.extents());
-
-    core::batch([](const auto &in1, const auto &in2,
-                   const auto &out) { detail::matmul_impl(in1, in2, out); },
-                std::tuple{rin1, rin2, rout},
-                std::tuple{urin1_exts, urin2_exts, urout_exts}, std::tuple{},
-                mpmode);
+    core::batch(
+        [](auto &&...elems) {
+            detail::matmul_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in1, in2, out},
+        std::tuple{core::slice_from_last<2>(in1.extents()),
+                   core::slice_from_last<2>(in2.extents()),
+                   core::slice_from_last<2>(out.extents())},
+        std::tuple{}, mpmode);
 }
 
-template <typename in1_t, typename in2_t>
+template <typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
-matmul(in1_t &&in1, in2_t &&in2, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
+matmul(In1Type &&In1, In2Type &&In2,
+       const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
 
-    const auto urin1_exts = core::slice_from_last<2>(rin1.extents());
-    const auto urin2_exts = core::slice_from_last<2>(rin2.extents());
-    const auto urout_exts =
-        extents<std::common_type_t<typename decltype(urin1_exts)::index_type,
-                                   typename decltype(urin2_exts)::index_type>,
-                decltype(urin1_exts)::static_extent(0),
-                decltype(urin2_exts)::static_extent(1)>{urin1_exts.extent(0),
-                                                        urin2_exts.extent(1)};
+    const auto uin1_exts = core::slice_from_last<2>(in1.extents());
+    const auto uin2_exts = core::slice_from_last<2>(in2.extents());
+    const auto uout_exts =
+        extents<std::common_type_t<typename decltype(uin1_exts)::index_type,
+                                   typename decltype(uin2_exts)::index_type>,
+                decltype(uin1_exts)::static_extent(0),
+                decltype(uin2_exts)::static_extent(1)>{uin1_exts.extent(0),
+                                                       uin2_exts.extent(1)};
 
     return core::batch(
-        [](const auto &in1, const auto &in2, const auto &out) {
-            detail::matmul_impl(in1, in2, out);
+        [](auto &&...elems) {
+            detail::matmul_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{rin1, rin2}, std::tuple{urin1_exts, urin2_exts, urout_exts},
+        std::tuple{in1, in2}, std::tuple{uin1_exts, uin2_exts, uout_exts},
         std::tuple{}, mpmode);
 }
 

--- a/ctmd/linalg/ctmd_linalg_norm.hpp
+++ b/ctmd/linalg/ctmd_linalg_norm.hpp
@@ -23,47 +23,46 @@ inline constexpr void norm_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename in_t, typename out_t>
-inline constexpr void norm(in_t &&in, out_t &&out,
+template <typename InType, typename OutType>
+inline constexpr void norm(InType &&In, OutType &&Out,
                            const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in = core::to_mdspan(std::forward<InType>(In));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
+
     if (mpmode == MPMode::SIMD) [[unlikely]] {
-        const auto pow = ctmd::multiply(in, in, mpmode);
-        ctmd::sum<-1>(pow, out, mpmode);
+        ctmd::sum<-1>(ctmd::multiply(in, in, mpmode), out, mpmode);
         ctmd::sqrt(out, out, mpmode);
 
     } else {
-        const auto rin = core::to_mdspan(std::forward<in_t>(in));
-        const auto rout = core::to_mdspan(std::forward<out_t>(out));
-
-        const auto urin_exts = core::slice_from_last<1>(rin.extents());
-        constexpr auto urout_exts =
-            extents<typename decltype(rout)::index_type>{};
-
         core::batch(
-            [](const auto &in, const auto &out) { detail::norm_impl(in, out); },
-            std::tuple{rin, rout}, std::tuple{urin_exts, urout_exts},
+            [](auto &&...elems) {
+                detail::norm_impl(std::forward<decltype(elems)>(elems)...);
+            },
+            std::tuple{in, out},
+            std::tuple{core::slice_from_last<1>(in.extents()),
+                       extents<uint8_t>{}},
             std::tuple{}, mpmode);
     }
 }
 
-template <typename in_t>
+template <typename InType>
 [[nodiscard]] inline constexpr auto
-norm(in_t &&in, const MPMode mpmode = MPMode::NONE) noexcept {
+norm(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in = core::to_mdspan(std::forward<InType>(In));
+
     if (mpmode == MPMode::SIMD) [[unlikely]] {
         return ctmd::sqrt(ctmd::sum<-1>(ctmd::multiply(in, in, mpmode), mpmode),
                           mpmode);
 
     } else {
-        const auto rin = core::to_mdspan(std::forward<in_t>(in));
-
-        const auto urin_exts = core::slice_from_last<1>(rin.extents());
-        constexpr auto urout_exts =
-            extents<typename decltype(rin)::index_type>{};
-
         return core::batch(
-            [](const auto &in, const auto &out) { detail::norm_impl(in, out); },
-            std::tuple{rin}, std::tuple{urin_exts, urout_exts}, std::tuple{},
-            mpmode);
+            [](auto &&...elems) {
+                detail::norm_impl(std::forward<decltype(elems)>(elems)...);
+            },
+            std::tuple{in},
+            std::tuple{core::slice_from_last<1>(in.extents()),
+                       extents<uint8_t>{}},
+            std::tuple{}, mpmode);
     }
 }
 

--- a/ctmd/linalg/ctmd_linalg_vecmat.hpp
+++ b/ctmd/linalg/ctmd_linalg_vecmat.hpp
@@ -55,42 +55,43 @@ inline constexpr void vecmat_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename in1_t, typename in2_t, typename out_t>
-inline constexpr void vecmat(in1_t &&in1, in2_t &&in2, out_t &&out,
+template <typename In1Type, typename In2Type, typename OutType>
+inline constexpr void vecmat(In1Type &&In1, In2Type &&In2, OutType &&Out,
                              const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
-    const auto rout = core::to_mdspan(std::forward<out_t>(out));
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
-    const auto urin1_exts = core::slice_from_last<1>(rin1.extents());
-    const auto urin2_exts = core::slice_from_last<2>(rin2.extents());
-    const auto urout_exts = core::slice_from_last<1>(rout.extents());
-
-    core::batch([](const auto &in1, const auto &in2,
-                   const auto &out) { detail::vecmat_impl(in1, in2, out); },
-                std::tuple{rin1, rin2, rout},
-                std::tuple{urin1_exts, urin2_exts, urout_exts}, std::tuple{},
-                mpmode);
+    core::batch(
+        [](auto &&...elems) {
+            detail::vecmat_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in1, in2, out},
+        std::tuple{core::slice_from_last<1>(in1.extents()),
+                   core::slice_from_last<2>(in2.extents()),
+                   core::slice_from_last<1>(out.extents())},
+        std::tuple{}, mpmode);
 }
 
-template <typename in1_t, typename in2_t>
+template <typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
-vecmat(in1_t &&in1, in2_t &&in2, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto rin1 = core::to_mdspan(std::forward<in1_t>(in1));
-    const auto rin2 = core::to_mdspan(std::forward<in2_t>(in2));
+vecmat(In1Type &&In1, In2Type &&In2,
+       const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in1 = core::to_mdspan(std::forward<In1Type>(In1));
+    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
 
-    const auto urin1_exts = core::slice_from_last<1>(rin1.extents());
-    const auto urin2_exts = core::slice_from_last<2>(rin2.extents());
-    const auto urout_exts =
-        extents<std::common_type_t<typename decltype(urin1_exts)::index_type,
-                                   typename decltype(urin2_exts)::index_type>,
-                decltype(urin2_exts)::static_extent(1)>{urin2_exts.extent(1)};
+    const auto uin1_exts = core::slice_from_last<1>(in1.extents());
+    const auto uin2_exts = core::slice_from_last<2>(in2.extents());
+    const auto uout_exts =
+        extents<std::common_type_t<typename decltype(uin1_exts)::index_type,
+                                   typename decltype(uin2_exts)::index_type>,
+                decltype(uin2_exts)::static_extent(1)>{uin2_exts.extent(1)};
 
     return core::batch(
-        [](const auto &in1, const auto &in2, const auto &out) {
-            detail::vecmat_impl(in1, in2, out);
+        [](auto &&...elems) {
+            detail::vecmat_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{rin1, rin2}, std::tuple{urin1_exts, urin2_exts, urout_exts},
+        std::tuple{in1, in2}, std::tuple{uin1_exts, uin2_exts, uout_exts},
         std::tuple{}, mpmode);
 }
 


### PR DESCRIPTION
This pull request introduces significant changes to the broadcasting and batch processing logic in the `ctmd` library, focusing on simplifying the codebase, improving performance, and enhancing flexibility. Key updates include the removal of the `need_broadcast` function, refactoring of batch processing functions, and the addition of new utilities for reshaping and validating `mdspan` types.

### Broadcasting and Batch Processing Refactor:
* Removed the `need_broadcast` function and its associated overloads, simplifying the broadcasting logic.
* Introduced a new `batch_impl` function that consolidates CPU and GPU-specific batch processing logic, replacing the previous separate implementations (`batch_impl_cpump`, `batch_impl_gpump`). [[1]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749R275-R292) [[2]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749L406-R400)
* Updated the main `batch` function to dynamically handle broadcasting and reshaping, improving computational efficiency and reducing redundant checks. [[1]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749L361-L383) [[2]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749L531-L593)

### Reshaping and Validation Enhancements:
* Added `is_always_reshapable` and `is_reshapable` utilities to validate whether an `mdspan` can be reshaped based on its properties (e.g., uniqueness, exhaustiveness).
* Introduced a new `reshape` function to enable safe and efficient reshaping of `mdspan` objects, ensuring compatibility with new extents.

### Code Simplification:
* Replaced the `to_mdspan` function with a more robust implementation that uses consistent naming conventions and improves readability.
* Removed redundant broadcasting logic in the `batch` function, consolidating it into a single streamlined implementation. [[1]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749L447-L500) [[2]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749L531-L593)