### PR TITLE
Feature empty

### DIFF
--- a/ctmd/ctmd.hpp
+++ b/ctmd/ctmd.hpp
@@ -13,6 +13,8 @@
 #include "ctmd_copy.hpp"
 #include "ctmd_cos.hpp"
 #include "ctmd_divide.hpp"
+#include "ctmd_empty.hpp"
+#include "ctmd_empty_like.hpp"
 #include "ctmd_equal.hpp"
 #include "ctmd_expand_dims.hpp"
 #include "ctmd_fill.hpp"

--- a/ctmd/ctmd_empty.hpp
+++ b/ctmd/ctmd_empty.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "core/ctmd_core.hpp"
+
+namespace ctmd {
+
+template <typename T, extents_c exts_t = extents<size_t>>
+[[nodiscard]] inline constexpr auto
+empty(const exts_t &exts = exts_t{}) noexcept {
+    return core::detail::create_out<T>(exts);
+}
+
+} // namespace ctmd

--- a/ctmd/ctmd_empty_like.hpp
+++ b/ctmd/ctmd_empty_like.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "ctmd_empty.hpp"
+
+namespace ctmd {
+
+template <typename InType>
+[[nodiscard]] inline constexpr auto empty_like(InType &&In) noexcept {
+    const auto in = core::to_mdspan(std::forward<InType>(In));
+
+    using T = std::remove_cvref_t<typename decltype(in)::element_type>;
+
+    return empty<T>(in.extents());
+}
+
+} // namespace ctmd

--- a/tests/empty/BUILD.bazel
+++ b/tests/empty/BUILD.bazel
@@ -1,0 +1,17 @@
+cc_test(
+    name = "main",
+    srcs = [
+        "main.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@gtest//:gtest_main",
+        "//:ctmd",
+    ],
+)

--- a/tests/empty/main.cpp
+++ b/tests/empty/main.cpp
@@ -1,0 +1,27 @@
+#include <gtest/gtest.h>
+
+#include "ctmd/ctmd_empty.hpp"
+
+namespace md = ctmd;
+
+TEST(stack, 1) {
+    using T = double;
+
+    constexpr auto x = md::empty<T>(md::extents<size_t, 1, 2, 3>{});
+
+    constexpr auto is_same_extents =
+        md::same(x.extents(), md::extents<size_t, 1, 2, 3>{});
+
+    ASSERT_TRUE(is_same_extents);
+}
+
+TEST(stack, 2) {
+    using T = double;
+
+    const auto x = md::empty<T>(md::dims<3>{1, 2, 3});
+
+    const auto is_same_extents =
+        md::same(x.extents(), md::extents<size_t, 1, 2, 3>{});
+
+    ASSERT_TRUE(is_same_extents);
+}

--- a/tests/empty/main.cpp
+++ b/tests/empty/main.cpp
@@ -15,7 +15,7 @@ TEST(stack, 1) {
     ASSERT_TRUE(is_same_extents);
 }
 
-TEST(stack, 2) {
+TEST(heap, 2) {
     using T = double;
 
     const auto x = md::empty<T>(md::dims<3>{1, 2, 3});

--- a/tests/empty_like/BUILD.bazel
+++ b/tests/empty_like/BUILD.bazel
@@ -1,0 +1,17 @@
+cc_test(
+    name = "main",
+    srcs = [
+        "main.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@gtest//:gtest_main",
+        "//:ctmd",
+    ],
+)

--- a/tests/empty_like/main.cpp
+++ b/tests/empty_like/main.cpp
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+
+#include "ctmd/ctmd_empty_like.hpp"
+
+namespace md = ctmd;
+
+TEST(stack, 1) {
+    using T = double;
+
+    constexpr auto x = md::empty<T>(md::extents<size_t, 1, 2, 3>{});
+    constexpr auto y = md::empty_like(x);
+
+    constexpr auto is_same_extents =
+        md::same(y.extents(), md::extents<size_t, 1, 2, 3>{});
+
+    ASSERT_TRUE(is_same_extents);
+}
+
+TEST(stack, 2) {
+    using T = double;
+
+    const auto x = md::empty<T>(md::dims<3>{1, 2, 3});
+    const auto y = md::empty_like(x);
+
+    const auto is_same_extents =
+        md::same(y.extents(), md::extents<size_t, 1, 2, 3>{});
+
+    ASSERT_TRUE(is_same_extents);
+}

--- a/tests/empty_like/main.cpp
+++ b/tests/empty_like/main.cpp
@@ -16,7 +16,7 @@ TEST(stack, 1) {
     ASSERT_TRUE(is_same_extents);
 }
 
-TEST(stack, 2) {
+TEST(heap, 2) {
     using T = double;
 
     const auto x = md::empty<T>(md::dims<3>{1, 2, 3});


### PR DESCRIPTION
This pull request introduces two new utility functions, `empty` and `empty_like`, to the `ctmd` library for creating multidimensional arrays with uninitialized values. It also adds corresponding unit tests to ensure their correctness. Below is a summary of the most important changes:

### Feature Additions:
* **`empty` function**: Added the `empty` function in `ctmd/ctmd_empty.hpp` to create uninitialized multidimensional arrays based on specified extents.
* **`empty_like` function**: Added the `empty_like` function in `ctmd/ctmd_empty_like.hpp` to create uninitialized arrays with the same extents as an existing array.

### Integration:
* **Header inclusion**: Updated `ctmd/ctmd.hpp` to include the new headers `ctmd_empty.hpp` and `ctmd_empty_like.hpp`.

### Testing:
* **Unit tests for `empty`**: Added a new Bazel test target (`tests/empty/BUILD.bazel`) and corresponding test cases in `tests/empty/main.cpp` to validate the functionality of the `empty` function. [[1]](diffhunk://#diff-602738a75482fe11e8b6659585ec103932c0882397b2a2daa205f4e433f9cc23R1-R17) [[2]](diffhunk://#diff-98e81a6f8f6c1c7a8dd4bce3383d863a7f6958594009640517c145eee1f461b9R1-R27)
* **Unit tests for `empty_like`**: Added a new Bazel test target (`tests/empty_like/BUILD.bazel`) and corresponding test cases in `tests/empty_like/main.cpp` to validate the functionality of the `empty_like` function. [[1]](diffhunk://#diff-602738a75482fe11e8b6659585ec103932c0882397b2a2daa205f4e433f9cc23R1-R17) [[2]](diffhunk://#diff-bdd76080d91c08c8f8b0b37ed455c5fa70bf8d4796a8c3a259643fdbb1f8f52dR1-R29)