### PR TITLE
modified

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,11 @@
-build --action_env=BAZEL_CXXOPTS="-std=c++20" --compilation_mode=opt
-run --action_env=BAZEL_CXXOPTS="-std=c++20" --compilation_mode=opt
-test --action_env=BAZEL_CXXOPTS="-std=c++20" --compilation_mode=opt
+build --action_env=BAZEL_CXXOPTS="-std=c++20"
+run --action_env=BAZEL_CXXOPTS="-std=c++20"
+test --action_env=BAZEL_CXXOPTS="-std=c++20"
+
+# build --repo_env=CC=clang
+# run --repo_env=CC=clang
+# test --repo_env=CC=clang
+
+build --compilation_mode=opt
+run --compilation_mode=opt
+test --compilation_mode=opt

--- a/.devcontainer/DockerFile
+++ b/.devcontainer/DockerFile
@@ -7,7 +7,9 @@ RUN apt-get update && \
     software-properties-common \
     git \
     gdb \
-    curl
+    curl \
+    lsb-release \
+    wget
 
 # Install ppa
 RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
@@ -16,6 +18,23 @@ RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
 # Install gcc 13 and g++ 13
 RUN apt-get install -y gcc-13 g++-13 && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13
+
+# Add LLVM official repository for Clang 17
+RUN wget https://apt.llvm.org/llvm.sh && \
+    chmod +x llvm.sh && \
+    ./llvm.sh 17 && \
+    rm llvm.sh
+
+# Set Clang 17 as the default compiler
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang-17 100 && \
+    update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-17 100 && \
+    update-alternatives --set cc /usr/bin/clang-17 && \
+    update-alternatives --set c++ /usr/bin/clang++-17
+
+RUN ln -s /usr/bin/clang-17 /usr/bin/clang && \
+    ln -s /usr/bin/clang++-17 /usr/bin/clang++
+
+RUN apt-get update && apt-get install -y libomp-17-dev
 
 # Install Bazelisk
 RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64 -o /usr/local/bin/bazel && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
     "build": {
         "dockerfile": "Dockerfile",
-        // "dockerfile": "omp_gpu/Dockerfile",
         "context": ".."
     },
     "runArgs": [

--- a/benchmarks/add/cpump/BUILD.bazel
+++ b/benchmarks/add/cpump/BUILD.bazel
@@ -14,6 +14,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -37,6 +38,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -60,6 +62,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -83,6 +86,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -106,6 +110,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -129,6 +134,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -152,6 +158,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -175,6 +182,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -198,6 +206,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -221,6 +230,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",

--- a/benchmarks/add/cpump/raw/BUILD.bazel
+++ b/benchmarks/add/cpump/raw/BUILD.bazel
@@ -6,7 +6,6 @@ cc_binary(
         ],
     copts = [
         "-O3",
-        
         "-funroll-loops",
         "-fno-exceptions",
         "-fno-rtti",
@@ -16,6 +15,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -30,7 +30,6 @@ cc_binary(
         ],
     copts = [
         "-O3",
-        
         "-funroll-loops",
         "-fno-exceptions",
         "-fno-rtti",
@@ -40,6 +39,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -54,7 +54,6 @@ cc_binary(
         ],
     copts = [
         "-O3",
-        
         "-funroll-loops",
         "-fno-exceptions",
         "-fno-rtti",
@@ -64,6 +63,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -78,7 +78,6 @@ cc_binary(
         ],
     copts = [
         "-O3",
-        
         "-funroll-loops",
         "-fno-exceptions",
         "-fno-rtti",
@@ -88,6 +87,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -102,7 +102,6 @@ cc_binary(
         ],
     copts = [
         "-O3",
-        
         "-funroll-loops",
         "-fno-exceptions",
         "-fno-rtti",
@@ -112,6 +111,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -126,7 +126,6 @@ cc_binary(
         ],
     copts = [
         "-O3",
-        
         "-funroll-loops",
         "-fno-exceptions",
         "-fno-rtti",
@@ -136,6 +135,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -150,7 +150,6 @@ cc_binary(
         ],
     copts = [
         "-O3",
-        
         "-funroll-loops",
         "-fno-exceptions",
         "-fno-rtti",
@@ -160,6 +159,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -174,7 +174,6 @@ cc_binary(
         ],
     copts = [
         "-O3",
-        
         "-funroll-loops",
         "-fno-exceptions",
         "-fno-rtti",
@@ -184,6 +183,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -197,8 +197,7 @@ cc_binary(
         "ps.cpp",
         ],
     copts = [
-        "-O3",
-        
+        "-O3",        
         "-funroll-loops",
         "-fno-exceptions",
         "-fno-rtti",
@@ -208,6 +207,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -222,7 +222,6 @@ cc_binary(
         ],
     copts = [
         "-O3",
-        
         "-funroll-loops",
         "-fno-exceptions",
         "-fno-rtti",
@@ -232,6 +231,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",

--- a/benchmarks/sin/cpump/BUILD.bazel
+++ b/benchmarks/sin/cpump/BUILD.bazel
@@ -16,6 +16,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",
@@ -40,6 +41,7 @@ cc_binary(
     ],
     linkopts = [
         "-lgomp",
+        "-L/usr/lib/llvm-17/lib",
     ],
     deps = [
         "@com_google_benchmark//:benchmark",

--- a/ctmd/core/ctmd_core_convert.hpp
+++ b/ctmd/core/ctmd_core_convert.hpp
@@ -51,7 +51,7 @@ reshape(InType &&In, const extents_t &new_extents = extents_t{}) noexcept {
     using in_t = decltype(in);
 
     assert(is_reshapable(in));
-    assert(size(in) == size(new_extents));
+    assert(ctmd::size(in.extents()) == ctmd::size(new_extents));
 
     return mdspan<typename in_t::element_type, extents_t>{in.data_handle(),
                                                           new_extents};

--- a/ctmd/core/ctmd_core_type.hpp
+++ b/ctmd/core/ctmd_core_type.hpp
@@ -20,6 +20,10 @@ namespace ctmd {
 
 using namespace std::experimental;
 
+#if defined(__GNUC__) && !defined(__llvm__) && !defined(__INTEL_COMPILER)
+#define REAL_GCC __GNUC__ // probably
+#endif
+
 namespace detail {
 
 template <typename T> struct make_extents_impl {

--- a/ctmd/ctmd.hpp
+++ b/ctmd/ctmd.hpp
@@ -3,6 +3,7 @@
 #include "linalg/ctmd_linalg.hpp"
 #include "random/ctmd_random.hpp"
 
+#include "ctmd_abs.hpp"
 #include "ctmd_add.hpp"
 #include "ctmd_all.hpp"
 #include "ctmd_allclose.hpp"

--- a/ctmd/ctmd_abs.hpp
+++ b/ctmd/ctmd_abs.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <cmath>
+
+#include "core/ctmd_core.hpp"
+
+namespace ctmd {
+namespace detail {
+
+template <mdspan_c in_t, mdspan_c out_t>
+    requires(in_t::rank() == 0 && out_t::rank() == 0)
+inline constexpr void abs_impl(const in_t &in, const out_t &out) noexcept {
+#ifdef REAL_GCC
+    out() = std::abs(in());
+
+#else
+    // NOTE: std::abs is not constexpr in clang 16.
+    out() = in() >= 0 ? in() : -in();
+
+#endif
+}
+
+} // namespace detail
+
+template <typename InType, typename OutType>
+inline constexpr void abs(InType &&In, OutType &&Out,
+                          const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in = core::to_mdspan(std::forward<InType>(In));
+    const auto out = core::to_mdspan(std::forward<OutType>(Out));
+
+    core::batch(
+        [](auto &&...elems) {
+            detail::abs_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
+}
+
+template <typename InType>
+[[nodiscard]] inline constexpr auto
+abs(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in = core::to_mdspan(std::forward<InType>(In));
+
+    return core::batch(
+        [](auto &&...elems) {
+            detail::abs_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
+        std::tuple{}, mpmode);
+}
+
+} // namespace ctmd

--- a/ctmd/ctmd_isclose.hpp
+++ b/ctmd/ctmd_isclose.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "core/ctmd_core.hpp"
+#include "ctmd_abs.hpp"
 
 namespace ctmd {
 namespace detail {
@@ -11,7 +11,8 @@ inline constexpr void isclose_impl(const in1_t &in1, const in2_t &in2,
                                    const out_t &out, const double &rtol,
                                    const double &atol) noexcept {
     using T = std::remove_cvref_t<decltype(in2())>;
-    out() = std::abs(in1() - in2()) <= ((T)atol + (T)rtol * std::abs(in2()));
+    out() = ctmd::abs(in1() - in2()) <=
+            (static_cast<T>(atol) + static_cast<T>(rtol) * ctmd::abs(in2()));
 }
 
 } // namespace detail

--- a/ctmd/ctmd_sqrt.hpp
+++ b/ctmd/ctmd_sqrt.hpp
@@ -7,10 +7,44 @@
 namespace ctmd {
 namespace detail {
 
+#ifndef REAL_GCC
+
+template <floating_point_c T>
+[[nodiscard]] inline constexpr T sqrt_newton_raphson(const T &x, const T &curr,
+                                                     const T &prev) noexcept {
+    return (curr == prev)
+               ? curr
+               : sqrt_newton_raphson(x, (curr + x / curr) / (T)2, curr);
+}
+
+#endif
+
 template <mdspan_c in_t, mdspan_c out_t>
     requires(in_t::rank() == 0 && out_t::rank() == 0)
 inline constexpr void sqrt_impl(const in_t &in, const out_t &out) noexcept {
+#ifdef REAL_GCC
     out() = std::sqrt(in());
+
+#else
+    // NOTE: std::abs is not constexpr in clang 16.
+
+    if constexpr (floating_point_c<typename in_t::element_type>) {
+        using T = typename in_t::element_type;
+
+        out() = (in() >= 0 && in() < std::numeric_limits<T>::infinity())
+                    ? sqrt_newton_raphson(in(), in(), (T)0)
+                    : std::numeric_limits<T>::quiet_NaN();
+
+    } else {
+        using T = float;
+
+        out() = (in() >= 0 && in() < std::numeric_limits<T>::infinity())
+                    ? sqrt_newton_raphson(static_cast<T>(in()),
+                                          static_cast<T>(in()), (T)0)
+                    : std::numeric_limits<T>::quiet_NaN();
+    }
+
+#endif
 }
 
 } // namespace detail

--- a/ctmd/linalg/ctmd_linalg_norm.hpp
+++ b/ctmd/linalg/ctmd_linalg_norm.hpp
@@ -17,7 +17,7 @@ inline constexpr void norm_impl(const in_t &in, const out_t &out) noexcept {
     for (typename in_t::size_type i = 0; i < in.extent(0); i++) {
         out() += in[i] * in[i];
     }
-    out() = std::sqrt(out());
+    out() = ctmd::sqrt(out());
 }
 
 } // namespace detail


### PR DESCRIPTION
This pull request introduces improvements to the build environment, updates dependencies, and refactors broadcasting logic in the codebase. Key changes include enabling Clang 17 as the default compiler in the development container, modifying Bazel build files to support LLVM libraries, and refactoring the broadcasting utility for better readability and maintainability.

### Build Environment Updates:
* [`.bazelrc`](diffhunk://#diff-544556920c45b42cbfe40159b082ce8af6bd929e492d076769226265f215832fL1-R11): Reorganized Bazel build settings by separating `--action_env` and `--compilation_mode` options for clarity. Commented out unused `--repo_env` entries for potential future use.
* [`.devcontainer/DockerFile`](diffhunk://#diff-c7503111f4faee9c731e6fcb92aaa43c9058db3527e67e4002d281e6b6735099L10-R12): Added `lsb-release` and `wget` as dependencies, integrated LLVM's official repository to install Clang 17, and set Clang 17 as the default compiler. Also installed `libomp-17-dev` for OpenMP support. [[1]](diffhunk://#diff-c7503111f4faee9c731e6fcb92aaa43c9058db3527e67e4002d281e6b6735099L10-R12) [[2]](diffhunk://#diff-c7503111f4faee9c731e6fcb92aaa43c9058db3527e67e4002d281e6b6735099R22-R38)
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L4): Removed commented-out Dockerfile reference to clean up the configuration.

### Bazel Build File Updates:
* `benchmarks/add/cpump/BUILD.bazel`, `benchmarks/add/cpump/raw/BUILD.bazel`, `benchmarks/sin/cpump/BUILD.bazel`: Added `-L/usr/lib/llvm-17/lib` to `linkopts` in multiple `cc_binary` targets to link against LLVM libraries. [[1]](diffhunk://#diff-9f7d969ae447b0033adfdf8b62f212b2e37f41c21045de3a7b061a37a6edc77dR17) [[2]](diffhunk://#diff-a530a543ae52eafcd7dc46d40e614fabae890f8f09b3d7fc592f0e552ce4e908R18) [[3]](diffhunk://#diff-aa8681c2a09af97d63062e871b56b1bf720bcbfb310aadcf91645e313a177aeaR19)

### Code Refactoring:
* [`ctmd/core/ctmd_core_broadcast.hpp`](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749L39-R47): Refactored broadcasting logic by introducing a `detail::broadcast_static_extent` helper function to improve readability and maintainability. Also restructured the `broadcast` function to leverage this helper for static extent calculations. [[1]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749L39-R47) [[2]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749L56-R88)