### PR TITLE
Refactory batch args

### DIFF
--- a/ctmd/abs.hpp
+++ b/ctmd/abs.hpp
@@ -32,8 +32,7 @@ inline constexpr void abs(InType &&In, OutType &&Out,
         [](auto &&...elems) {
             detail::abs_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0>{}, mpmode, in, out);
 }
 
 template <typename InType>
@@ -45,8 +44,7 @@ abs(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::abs_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode, in);
 }
 
 } // namespace ctmd

--- a/ctmd/abs.hpp
+++ b/ctmd/abs.hpp
@@ -33,7 +33,7 @@ inline constexpr void abs(InType &&In, OutType &&Out,
             detail::abs_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename InType>
@@ -46,7 +46,7 @@ abs(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
             detail::abs_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/add.hpp
+++ b/ctmd/add.hpp
@@ -27,7 +27,7 @@ inline constexpr void add(In1Type &&In1, In2Type &&In2, OutType &&Out,
         },
         std::tuple{in1, in2, out},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename In1Type, typename In2Type>
@@ -42,7 +42,7 @@ add(In1Type &&In1, In2Type &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
         },
         std::tuple{in1, in2},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/add.hpp
+++ b/ctmd/add.hpp
@@ -21,21 +21,11 @@ inline constexpr void add(In1Type &&In1, In2Type &&In2, OutType &&Out,
     const auto in2 = core::to_const_mdspan(std::forward<In2Type>(In2));
     const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
-    // core::batch(
-    //     [](auto &&...elems) {
-    //         detail::add_impl(std::forward<decltype(elems)>(elems)...);
-    //     },
-    //     std::tuple{in1, in2, out},
-    //     std::tuple{extents<uint8_t>{}, extents<uint8_t>{},
-    //     extents<uint8_t>{}}, mpmode);
-
-    core::batch_new(
+    core::batch(
         [](auto &&...elems) {
             detail::add_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0, 0>{},
-        std::index_sequence<in1.rank(), in2.rank(), out.rank()>{}, mpmode, in1,
-        in2, out);
+        std::index_sequence<0, 0, 0>{}, mpmode, in1, in2, out);
 }
 
 template <typename In1Type, typename In2Type>
@@ -44,13 +34,11 @@ add(In1Type &&In1, In2Type &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
     const auto in1 = core::to_const_mdspan(std::forward<In1Type>(In1));
     const auto in2 = core::to_const_mdspan(std::forward<In2Type>(In2));
 
-    return core::batch_out_new(
+    return core::batch_out(
         [](auto &&...elems) {
             detail::add_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{},
-        std::index_sequence<in1.rank(), in2.rank()>{},
-        std::integral_constant<size_t, 0>{}, extents<uint8_t>{}, mpmode, in1,
+        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode, in1,
         in2);
 }
 

--- a/ctmd/add.hpp
+++ b/ctmd/add.hpp
@@ -21,13 +21,21 @@ inline constexpr void add(In1Type &&In1, In2Type &&In2, OutType &&Out,
     const auto in2 = core::to_const_mdspan(std::forward<In2Type>(In2));
     const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
-    core::batch(
+    // core::batch(
+    //     [](auto &&...elems) {
+    //         detail::add_impl(std::forward<decltype(elems)>(elems)...);
+    //     },
+    //     std::tuple{in1, in2, out},
+    //     std::tuple{extents<uint8_t>{}, extents<uint8_t>{},
+    //     extents<uint8_t>{}}, mpmode);
+
+    core::batch_new(
         [](auto &&...elems) {
             detail::add_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2, out},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0, 0>{},
+        std::index_sequence<in1.rank(), in2.rank(), out.rank()>{}, mpmode, in1,
+        in2, out);
 }
 
 template <typename In1Type, typename In2Type>
@@ -36,13 +44,14 @@ add(In1Type &&In1, In2Type &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
     const auto in1 = core::to_const_mdspan(std::forward<In1Type>(In1));
     const auto in2 = core::to_const_mdspan(std::forward<In2Type>(In2));
 
-    return core::batch_out(
+    return core::batch_out_new(
         [](auto &&...elems) {
             detail::add_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0>{},
+        std::index_sequence<in1.rank(), in2.rank()>{},
+        std::integral_constant<size_t, 0>{}, extents<uint8_t>{}, mpmode, in1,
+        in2);
 }
 
 } // namespace ctmd

--- a/ctmd/array_equal.hpp
+++ b/ctmd/array_equal.hpp
@@ -27,8 +27,8 @@ template <typename In1Type, typename In2Type>
 
     } else {
         for (typename in1_t::size_type i = 0; i < in1.extent(0); i++) {
-            if (!array_equal(core::submdspan_from_left(in1, i),
-                             core::submdspan_from_left(in2, i))) {
+            if (!ctmd::array_equal(core::submdspan_from_left(in1, i),
+                                   core::submdspan_from_left(in2, i))) {
                 return false;
             }
         }

--- a/ctmd/atan2.hpp
+++ b/ctmd/atan2.hpp
@@ -33,7 +33,7 @@ inline constexpr void atan2(In1Type &&In1, In2Type &&In2, OutType &&Out,
         },
         std::tuple{in1, in2, out},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename In1Type, typename In2Type>
@@ -49,7 +49,7 @@ atan2(In1Type &&In1, In2Type &&In2,
         },
         std::tuple{in1, in2},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/atan2.hpp
+++ b/ctmd/atan2.hpp
@@ -31,9 +31,7 @@ inline constexpr void atan2(In1Type &&In1, In2Type &&In2, OutType &&Out,
         [](auto &&...elems) {
             detail::atan2_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2, out},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0, 0>{}, mpmode, in1, in2, out);
 }
 
 template <typename In1Type, typename In2Type>
@@ -47,9 +45,8 @@ atan2(In1Type &&In1, In2Type &&In2,
         [](auto &&...elems) {
             detail::atan2_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode, in1,
+        in2);
 }
 
 } // namespace ctmd

--- a/ctmd/clip.hpp
+++ b/ctmd/clip.hpp
@@ -31,10 +31,7 @@ inline constexpr void clip(InType &&In, MinType &&Min, MaxType &&Max,
         [](auto &&...elems) {
             detail::clip_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in, min, max, out},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{},
-                   extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0, 0, 0>{}, mpmode, in, min, max, out);
 }
 
 template <typename InType, typename MinType, typename MaxType>
@@ -49,10 +46,8 @@ clip(InType &&In, MinType &&Min, MaxType &&Max,
         [](auto &&...elems) {
             detail::clip_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in, min, max},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{},
-                   extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0, 0>{}, ctmd::extents<uint8_t>{}, mpmode, in,
+        min, max);
 }
 
 } // namespace ctmd

--- a/ctmd/clip.hpp
+++ b/ctmd/clip.hpp
@@ -34,7 +34,7 @@ inline constexpr void clip(InType &&In, MinType &&Min, MaxType &&Max,
         std::tuple{in, min, max, out},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{},
                    extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename InType, typename MinType, typename MaxType>
@@ -52,7 +52,7 @@ clip(InType &&In, MinType &&Min, MaxType &&Max,
         std::tuple{in, min, max},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{},
                    extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/concatenate.hpp
+++ b/ctmd/concatenate.hpp
@@ -130,12 +130,12 @@ concatenate(std::tuple<InsTypes...> &&Ins) noexcept {
              const size_t extent = std::get<Is>(ins).extent(axis);
              constexpr size_t stride = 1;
 
-             ctmd::copy(std::get<Is>(ins),
-                        [&]<size_t... Js>(std::index_sequence<Js...>) {
-                            return core::submdspan_from_left(
-                                out, ((void)Js, ctmd::full_extent)...,
-                                ctmd::strided_slice{offset, extent, stride});
-                        }(std::make_index_sequence<axis>{}));
+             ctmd::copy(std::get<Is>(ins), [&]<size_t... Js>(
+                                               std::index_sequence<Js...>) {
+                 return core::submdspan_from_left(
+                     core::to_mdspan(out), ((void)Js, ctmd::full_extent)...,
+                     ctmd::strided_slice{offset, extent, stride});
+             }(std::make_index_sequence<axis>{}));
          })(),
          ...);
     }(std::make_index_sequence<num_ins>{});

--- a/ctmd/copy.hpp
+++ b/ctmd/copy.hpp
@@ -23,8 +23,7 @@ inline constexpr void copy(InType &&In, OutType &&Out,
         [](auto &&...elems) {
             detail::copy_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0>{}, mpmode, in, out);
 }
 
 template <typename InType>
@@ -36,8 +35,7 @@ copy(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::copy_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode, in);
 }
 
 } // namespace ctmd

--- a/ctmd/copy.hpp
+++ b/ctmd/copy.hpp
@@ -24,7 +24,7 @@ inline constexpr void copy(InType &&In, OutType &&Out,
             detail::copy_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename InType>
@@ -37,7 +37,7 @@ copy(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
             detail::copy_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/core/broadcast.hpp
+++ b/ctmd/core/broadcast.hpp
@@ -6,27 +6,29 @@
 namespace ctmd {
 namespace core {
 
-template <size_t SliceRank, extents_c in_t>
+template <size_t offset, size_t rank, extents_c in_t>
 [[nodiscard]] inline constexpr auto
-slice_from_left(const in_t &in = in_t{}) noexcept {
-    static_assert(SliceRank <= in_t::rank(), "SliceRank exceeds rank.");
+slice_with_offset(const in_t &in = in_t{}) noexcept {
+    static_assert(in_t::rank() >= offset + rank,
+                  "Slice rank exceeds input rank.");
 
-    return [&in]<size_t... Is>(std::index_sequence<Is...>) {
-        return extents<typename in_t::index_type, in_t::static_extent(Is)...>{
-            in.extent(Is)...};
-    }(std::make_index_sequence<SliceRank>{});
+    return [&]<size_t... Is>(std::index_sequence<Is...>) {
+        return extents<typename in_t::index_type,
+                       in_t::static_extent(offset + Is)...>{
+            in.extent(offset + Is)...};
+    }(std::make_index_sequence<rank>{});
 }
 
-template <size_t SliceRank, extents_c in_t>
+template <size_t rank, extents_c in_t>
+[[nodiscard]] inline constexpr auto
+slice_from_left(const in_t &in = in_t{}) noexcept {
+    return slice_with_offset<0, rank>(in);
+}
+
+template <size_t rank, extents_c in_t>
 [[nodiscard]] inline constexpr auto
 slice_from_right(const in_t &in = in_t{}) noexcept {
-    static_assert(SliceRank <= in_t::rank(), "SliceRank exceeds rank.");
-
-    return [&in]<size_t... Is>(std::index_sequence<Is...>) {
-        return extents<typename in_t::index_type,
-                       in_t::static_extent(in_t::rank() - SliceRank + Is)...>{
-            in.extent(in_t::rank() - SliceRank + Is)...};
-    }(std::make_index_sequence<SliceRank>{});
+    return slice_with_offset<in_t::rank() - rank, rank>(in);
 }
 
 template <extents_c in1_t, extents_c in2_t, extents_c... ins_t>
@@ -37,8 +39,8 @@ template <extents_c in1_t, extents_c in2_t, extents_c... ins_t>
                                        typename in2_t::index_type>;
 
     const auto cexts =
-        [&in1, &in2]<size_t... Is, size_t... Js>(std::index_sequence<Is...>,
-                                                 std::index_sequence<Js...>) {
+        [&]<size_t... Is, size_t... Js>(std::index_sequence<Is...>,
+                                        std::index_sequence<Js...>) {
             return extents<index_t, in1_t::static_extent(Is)...,
                            in2_t::static_extent(Js)...>{
                 static_cast<index_t>(in1.extent(Is))...,
@@ -88,10 +90,9 @@ template <extents_c in1_t, extents_c in2_t, extents_c... ins_t>
                                        typename in2_t::index_type>;
     constexpr size_t brank = std::max(in1_t::rank(), in2_t::rank());
 
-    const auto bexts = [&in1, &in2]<size_t... Is>(std::index_sequence<Is...>) {
+    const auto bexts = [&]<size_t... Is>(std::index_sequence<Is...>) {
         return extents<index_t, detail::broadcast_static_extent<
-                                    in1_t, in2_t, Is, brank>()...>{[&in1,
-                                                                    &in2]() {
+                                    in1_t, in2_t, Is, brank>()...>{[&]() {
             const size_t x1 = (Is < brank - in1_t::rank()
                                    ? 1
                                    : in1.extent(Is - (brank - in1_t::rank())));
@@ -168,6 +169,78 @@ broadcast_to(const in_t &in = in_t{},
     }
 }
 
+template <size_t offset, size_t brank, mdspan_c in_t, extents_c new_bexts_t>
+[[nodiscard]] inline constexpr auto
+broadcast_to_new(const in_t &in = in_t{},
+                 const new_bexts_t &new_bexts = new_bexts_t{}) noexcept {
+    static_assert(in_t::rank() >= offset + brank, "Incompatible rank");
+    static_assert(new_bexts_t::rank() >= brank);
+
+    if constexpr (brank == new_bexts_t::rank() &&
+                  []<size_t... Is>(std::index_sequence<Is...>) {
+                      return ((in_t::static_extent(offset + Is) != ctmd::dyn &&
+                               in_t::static_extent(offset + Is) ==
+                                   new_bexts_t::static_extent(Is)) &&
+                              ...);
+                  }(std::make_index_sequence<brank>{})) {
+        return in;
+
+    } else if constexpr (in_t::rank() == 0) {
+        using size_type = typename new_bexts_t::size_type;
+
+        auto new_strides = std::array<size_type, new_bexts_t::rank()>{};
+
+        for (size_t i = 0; i < new_bexts_t::rank(); i++) {
+            new_strides[i] = 0;
+        }
+
+        return mdspan<typename in_t::element_type, new_bexts_t, layout_stride,
+                      typename in_t::accessor_type>{
+            in.data_handle(), layout_stride::mapping{new_bexts, new_strides}};
+
+    } else {
+        using size_type = std::common_type_t<typename in_t::size_type,
+                                             typename new_bexts_t::size_type>;
+
+        auto new_strides =
+            std::array<size_type, in_t::rank() - brank + new_bexts_t::rank()>{};
+
+        for (size_t i = 0; i < new_strides.size(); i++) {
+            if (i < offset) {
+                new_strides[i] = static_cast<size_type>(in.stride(i));
+
+            } else if (i < offset + (new_bexts_t::rank() - brank)) {
+                new_strides[i] = 0;
+
+            } else if (i < offset + new_bexts_t::rank()) {
+                const size_t j = i - (new_bexts_t::rank() - brank);
+
+                if (in.extent(j) == new_bexts.extent(i - offset)) {
+                    new_strides[i] = static_cast<size_type>(in.stride(j));
+
+                } else if (in.extent(j) == 1) {
+                    new_strides[i] = 0;
+
+                } else {
+                    assert(false);
+                }
+
+            } else {
+                new_strides[i] = static_cast<size_type>(
+                    in.stride(i - (new_bexts_t::rank() - brank)));
+            }
+        }
+
+        auto new_extents = concatenate(
+            slice_from_left<offset>(in.extents()), new_bexts,
+            slice_from_right<in_t::rank() - offset - brank>(in.extents()));
+
+        return mdspan<typename in_t::element_type, decltype(new_extents),
+                      layout_stride, typename in_t::accessor_type>{
+            in.data_handle(), layout_stride::mapping{new_extents, new_strides}};
+    }
+}
+
 namespace detail {
 
 template <size_t BatchRank, typename Func, mdspan_c in_t, mdspan_c... ins_t>
@@ -185,33 +258,27 @@ inline constexpr void batch_impl_none(Func &&func, const in_t &in,
     }
 }
 
-// template <typename Func, mdspan_c in_t, mdspan_c... ins_t,
-//           extents_c... uinexts_t>
-// inline constexpr void
-// batch_impl_none_new(Func &&func, const in_t &in, const ins_t &...ins,
-//                     const std::tuple<uinexts_t...> &uinexts) noexcept {
+template <size_t brank, typename Func, size_t offset, size_t... offsets,
+          mdspan_c in_t, mdspan_c... ins_t>
+inline constexpr void
+batch_impl_none_new(Func &&func, std::index_sequence<offset, offsets...>,
+                    const in_t &in, const ins_t &...ins) noexcept {
+    static_assert(sizeof...(offsets) == sizeof...(ins_t),
+                  "Number of offsets must match number of inputs.");
 
-//     if constexpr (in_t::rank() ==
-//                   std::tuple_element_t<0, std::tuple<uinexts_t...>>::rank())
-//                   {
-//         std::forward<Func>(func)(in, ins...);
+    if constexpr (brank == 0) {
+        std::forward<Func>(func)(in, ins...);
 
-//     } else {
-//         for (typename in_t::index_type i = 0; i < in.extent(0); i++) {
-//             // batch_impl_none_new(std::forward<Func>(func),
-//             //                     submdspan_from_left(in, i),
-//             //                     submdspan_from_left(ins, i)..., uinexts);
-
-//             [&]<size_t... Is>(std::index_sequence<Is...>) {
-//                 batch_impl_none_new(
-//                     std::forward<Func>(func),
-//                     submdspan_from_right(in, i,
-//                                          ((void)Is, ctmd::full_extent)...),
-//                     submdspan_from_right(ins, i)..., uinexts);
-//             }(std::make_index_sequence<sizeof...(uinexts_t)>{});
-//         }
-//     }
-// }
+    } else {
+        for (size_t i = 0; i < in.extent(offset); i++) {
+            batch_impl_none_new<brank - 1>(
+                std::forward<Func>(func),
+                std::index_sequence<offset, offsets...>{},
+                submdspan_from_left<offset>(in, i),
+                submdspan_from_left<offsets>(ins, i)...);
+        }
+    }
+}
 
 #ifdef _OPENMP
 
@@ -231,35 +298,57 @@ inline constexpr void batch_impl_cpump(Func &&func, const in_t &in,
     }
 }
 
-#if false // TODO: fix this
+template <size_t brank, typename Func, size_t offset, size_t... offsets,
+          mdspan_c in_t, mdspan_c... ins_t>
+inline constexpr void
+batch_impl_cpump_new(Func &&func, std::index_sequence<offset, offsets...>,
+                     const in_t &in, const ins_t &...ins) noexcept {
+    static_assert(sizeof...(offsets) == sizeof...(ins_t),
+                  "Number of offsets must match number of inputs.");
 
-template <size_t BatchRank, typename Func, mdspan_c in_t, mdspan_c... ins_t>
-inline constexpr void batch_impl_gpump(Func &&func, const in_t &in,
-                                           const ins_t &...ins) noexcept {
-    if constexpr (BatchRank == 0) {
+    if constexpr (brank == 0) {
         std::forward<Func>(func)(in, ins...);
 
     } else {
-#pragma omp target teams distribute parallel for
+#pragma omp parallel for
+        for (size_t i = 0; i < in.extent(offset); i++) {
+            batch_impl_none_new<brank - 1>(
+                std::forward<Func>(func),
+                std::index_sequence<offset, offsets...>{},
+                submdspan_from_left<offset>(in, i),
+                submdspan_from_left<offsets>(ins, i)...);
+        }
+    }
+}
+
+template <typename Func, size_t uin_rank, size_t... uins_rank, mdspan_c in_t,
+          mdspan_c... ins_t>
+inline constexpr void
+batch_impl_cpump_new(Func &&func, std::index_sequence<uin_rank, uins_rank...>,
+                     const in_t &in, const ins_t &...ins) noexcept {
+    if constexpr (in_t::rank() == uin_rank) {
+        std::forward<Func>(func)(in, ins...);
+
+    } else {
+#pragma omp parallel for
         for (typename in_t::index_type i = 0; i < in.extent(0); i++) {
-            batch_impl_none<BatchRank - 1>(std::forward<Func>(func),
-                                               submdspan_from_left(in, i),
-                                               submdspan_from_left(ins, i)...);
+            batch_impl_none_new(std::forward<Func>(func),
+                                std::index_sequence<uin_rank, uins_rank...>{},
+                                submdspan_from_left(in, i),
+                                submdspan_from_left(ins, i)...);
         }
     }
 }
 
 #endif
 
-#endif
-
-template <size_t BatchRank, typename Func, mdspan_c in_t, mdspan_c... ins_t>
+template <size_t BatchRank, typename Func, mdspan_c... ins_t>
 inline constexpr void batch_impl(Func &&func, const MPMode mpmode,
-                                 const in_t &in, const ins_t &...ins) noexcept {
+                                 const ins_t &...ins) noexcept {
     if (!std::is_constant_evaluated()) [[likely]] {
         if (mpmode == MPMode::CPUMP) [[unlikely]] {
 #ifdef _OPENMP
-            batch_impl_cpump<BatchRank>(std::forward<Func>(func), in, ins...);
+            batch_impl_cpump<BatchRank>(std::forward<Func>(func), ins...);
             return;
 #else
             assert(false);
@@ -267,7 +356,28 @@ inline constexpr void batch_impl(Func &&func, const MPMode mpmode,
         }
     }
 
-    batch_impl_none<BatchRank>(std::forward<Func>(func), in, ins...);
+    batch_impl_none<BatchRank>(std::forward<Func>(func), ins...);
+}
+
+template <size_t brank, typename Func, size_t... offsets, mdspan_c... ins_t>
+inline constexpr void
+batch_impl_new(Func &&func, std::index_sequence<offsets...>,
+               const MPMode mpmode, const ins_t &...ins) noexcept {
+    if (!std::is_constant_evaluated()) [[likely]] {
+        if (mpmode == MPMode::CPUMP) [[unlikely]] {
+#ifdef _OPENMP
+            batch_impl_cpump_new<brank>(std::forward<Func>(func),
+                                        std::index_sequence<offsets...>{},
+                                        ins...);
+            return;
+#else
+            assert(false);
+#endif
+        }
+    }
+
+    batch_impl_none_new<brank>(std::forward<Func>(func),
+                               std::index_sequence<offsets...>{}, ins...);
 }
 
 } // namespace detail
@@ -289,7 +399,7 @@ create_out(const std::tuple<ins_t...> &ins,
            const std::tuple<uinexts_t...> &uinexts) noexcept {
     using element_t = std::common_type_t<T, element_type_t<ins_t>...>;
 
-    const auto bexts = [&ins]<size_t... Is>(std::index_sequence<Is...>) {
+    const auto bexts = [&]<size_t... Is>(std::index_sequence<Is...>) {
         return broadcast(
             slice_from_left<
                 std::tuple_element_t<Is, std::tuple<ins_t...>>::rank() -
@@ -301,6 +411,30 @@ create_out(const std::tuple<ins_t...> &ins,
         core::concatenate(bexts, std::get<sizeof...(ins_t)>(uinexts)));
 }
 
+template <typename T = int8_t, size_t... offsets, size_t... branks,
+          size_t uout_offset, extents_c uout_exts_t, mdspan_c... ins_t>
+    requires(sizeof...(offsets) == sizeof...(ins_t) &&
+             sizeof...(branks) == sizeof...(ins_t))
+[[nodiscard]] inline constexpr auto
+create_out_new(std::index_sequence<offsets...>, std::index_sequence<branks...>,
+               std::integral_constant<size_t, uout_offset>,
+               const uout_exts_t &uout_exts, const ins_t &...ins) noexcept {
+    using element_t = std::common_type_t<T, element_type_t<ins_t>...>;
+
+    constexpr std::array ofst = {offsets...};
+    constexpr std::array br = {branks...};
+    auto ins_tuple = std::forward_as_tuple(ins...);
+
+    const auto bexts = [&]<size_t... Is>(std::index_sequence<Is...>) {
+        return broadcast(slice_with_offset<ofst[Is], br[Is]>(
+            std::get<Is>(ins_tuple).extents())...);
+    }(std::make_index_sequence<sizeof...(ins_t)>{});
+
+    return create_out<element_t>(core::concatenate(
+        slice_from_left<uout_offset>(uout_exts), bexts,
+        slice_from_right<uout_exts_t::rank() - uout_offset>(uout_exts)));
+}
+
 template <typename T = int8_t, mdspan_c... ins_t, extents_c... uinexts_t>
     requires(sizeof...(ins_t) < sizeof...(uinexts_t) - 1)
 [[nodiscard]] inline constexpr auto
@@ -308,7 +442,7 @@ create_out(const std::tuple<ins_t...> &ins,
            const std::tuple<uinexts_t...> &uinexts) noexcept {
     using element_t = std::common_type_t<T, element_type_t<ins_t>...>;
 
-    const auto bexts = [&ins]<size_t... Is>(std::index_sequence<Is...>) {
+    const auto bexts = [&]<size_t... Is>(std::index_sequence<Is...>) {
         return broadcast(
             slice_from_left<
                 std::tuple_element_t<Is, std::tuple<ins_t...>>::rank() -
@@ -316,7 +450,7 @@ create_out(const std::tuple<ins_t...> &ins,
                 std::get<Is>(ins).extents())...);
     }(std::make_index_sequence<sizeof...(ins_t)>{});
 
-    return [&uinexts, &bexts]<size_t... Is>(std::index_sequence<Is...>) {
+    return [&]<size_t... Is>(std::index_sequence<Is...>) {
         return std::tuple{create_out<element_t>(core::concatenate(
             bexts, std::get<sizeof...(ins_t) + Is>(uinexts)))...};
     }(std::make_index_sequence<sizeof...(uinexts_t) - sizeof...(ins_t)>{});
@@ -363,7 +497,7 @@ inline constexpr void batch(Func &&func, const std::tuple<ins_t...> &ins,
                 std::tuple_element_t<0, std::tuple<ins_t...>>::rank() -
                 std::tuple_element_t<0, std::tuple<uinexts_t...>>::rank();
 
-            const bool same_bexts = [&ins]<size_t... Is>(
+            const bool same_bexts = [&]<size_t... Is>(
                                         std::index_sequence<Is...>) {
                 return same(std::make_tuple(
                     slice_from_left<brank>(std::get<Is>(ins).extents())...));
@@ -371,7 +505,7 @@ inline constexpr void batch(Func &&func, const std::tuple<ins_t...> &ins,
 
             if (same_bexts) [[likely]] {
                 const bool is_flattable =
-                    [&ins]<size_t... Is>(std::index_sequence<Is...>) {
+                    [&]<size_t... Is>(std::index_sequence<Is...>) {
                         return (core::is_reshapable(std::get<Is>(ins)) && ...);
                     }(std::make_index_sequence<sizeof...(ins_t)>{});
 
@@ -383,7 +517,7 @@ inline constexpr void batch(Func &&func, const std::tuple<ins_t...> &ins,
                     const size_t bsize = size(
                         slice_from_left<brank>(std::get<0>(ins).extents()));
 
-                    const auto fins = [&ins, &uinexts, &bsize]<size_t... Is>(
+                    const auto fins = [&]<size_t... Is>(
                                           std::index_sequence<Is...>) {
                         return std::tuple{reshape(
                             std::get<Is>(ins),
@@ -414,7 +548,7 @@ inline constexpr void batch(Func &&func, const std::tuple<ins_t...> &ins,
         }
 
         // Broadcasting
-        const auto bexts = [&ins]<size_t... Is>(std::index_sequence<Is...>) {
+        const auto bexts = [&]<size_t... Is>(std::index_sequence<Is...>) {
             return broadcast(
                 slice_from_left<
                     std::tuple_element_t<Is, std::tuple<ins_t...>>::rank() -
@@ -424,8 +558,7 @@ inline constexpr void batch(Func &&func, const std::tuple<ins_t...> &ins,
 
         constexpr size_t brank = decltype(bexts)::rank();
 
-        const auto bins = [&ins, &uinexts,
-                           &bexts]<size_t... Is>(std::index_sequence<Is...>) {
+        const auto bins = [&]<size_t... Is>(std::index_sequence<Is...>) {
             return std::tuple{
                 broadcast_to(std::get<Is>(ins),
                              concatenate(bexts, std::get<Is>(uinexts)))...};
@@ -439,6 +572,30 @@ inline constexpr void batch(Func &&func, const std::tuple<ins_t...> &ins,
             },
             bins);
     }
+}
+
+template <typename Func, size_t... offsets, size_t... branks, mdspan_c... ins_t>
+    requires(sizeof...(offsets) == sizeof...(ins_t) &&
+             sizeof...(branks) == sizeof...(ins_t))
+inline constexpr void batch_new(Func &&func, std::index_sequence<offsets...>,
+                                std::index_sequence<branks...>,
+                                const MPMode mpmode,
+                                const ins_t &...ins) noexcept {
+    constexpr std::array ofst = {offsets...};
+    constexpr std::array br = {branks...};
+    auto ins_tuple = std::forward_as_tuple(ins...);
+
+    const auto bexts = [&]<size_t... Is>(std::index_sequence<Is...>) {
+        return broadcast(slice_with_offset<ofst[Is], br[Is]>(
+            std::get<Is>(ins_tuple).extents())...);
+    }(std::make_index_sequence<sizeof...(ins_t)>{});
+
+    [&]<size_t... Is>(std::index_sequence<Is...>) {
+        detail::batch_impl_new<bexts.rank()>(
+            std::forward<Func>(func), std::index_sequence<offsets...>{}, mpmode,
+            broadcast_to_new<ofst[Is], br[Is]>(std::get<Is>(ins_tuple),
+                                               bexts)...);
+    }(std::make_index_sequence<sizeof...(ins_t)>{});
 }
 
 template <typename T = int8_t, typename Func, mdspan_c... ins_t,
@@ -457,6 +614,29 @@ batch_out(Func &&func, const std::tuple<ins_t...> &ins,
     return out;
 }
 
+template <typename T = int8_t, typename Func, size_t... offsets,
+          size_t... branks, size_t uout_offset, extents_c uout_exts_t,
+          mdspan_c... ins_t>
+    requires(sizeof...(offsets) == sizeof...(ins_t) &&
+             sizeof...(branks) == sizeof...(ins_t))
+[[nodiscard]] inline constexpr auto
+batch_out_new(Func &&func, std::index_sequence<offsets...>,
+              std::index_sequence<branks...>,
+              std::integral_constant<size_t, uout_offset>,
+              const uout_exts_t &uout_exts, const MPMode mpmode,
+              const ins_t &...ins) noexcept {
+    auto out = create_out_new<T>(
+        std::index_sequence<offsets...>{}, std::index_sequence<branks...>{},
+        std::integral_constant<size_t, uout_offset>{}, uout_exts, ins...);
+
+    batch_new(std::forward<Func>(func),
+              std::index_sequence<offsets..., uout_offset>{},
+              std::index_sequence<branks..., std::max(branks...)>{}, mpmode,
+              ins..., core::to_mdspan(out));
+
+    return out;
+}
+
 template <typename T = int8_t, typename Func, mdspan_c... ins_t,
           extents_c... uinexts_t>
     requires(sizeof...(ins_t) < sizeof...(uinexts_t) - 1)
@@ -466,8 +646,7 @@ batch_out(Func &&func, const std::tuple<ins_t...> &ins,
           const MPMode mpmode) noexcept {
     auto outs = create_out<T>(ins, uinexts);
 
-    [&func, &ins, &outs, &uinexts,
-     &mpmode]<size_t... Is>(std::index_sequence<Is...>) {
+    [&]<size_t... Is>(std::index_sequence<Is...>) {
         batch(std::forward<Func>(func),
               std::tuple_cat(ins,
                              std::make_tuple(to_mdspan(std::get<Is>(outs))...)),

--- a/ctmd/core/broadcast.hpp
+++ b/ctmd/core/broadcast.hpp
@@ -10,7 +10,7 @@ template <size_t offset, size_t rank, extents_c in_t>
 [[nodiscard]] inline constexpr auto
 slice_with_offset(const in_t &in = in_t{}) noexcept {
     static_assert(in_t::rank() >= offset + rank,
-                  "Slice rank exceeds input rank.");
+                  "Incompatible offset and rank for slicing.");
 
     return [&]<size_t... Is>(std::index_sequence<Is...>) {
         return extents<typename in_t::index_type,
@@ -114,67 +114,16 @@ template <extents_c in1_t, extents_c in2_t, extents_c... ins_t>
     }
 }
 
-template <mdspan_c in_t, extents_c extents_t>
-[[nodiscard]] inline constexpr auto
-broadcast_to(const in_t &in = in_t{},
-             const extents_t &new_extents = extents_t{}) noexcept {
-    if constexpr (in_t::rank() == extents_t::rank() &&
-                  in_t::rank_dynamic() == 0 && extents_t::rank_dynamic() == 0 &&
-                  []<size_t... Is>(std::index_sequence<Is...>) {
-                      return ((in_t::static_extent(Is) ==
-                               extents_t::static_extent(Is)) &&
-                              ...);
-                  }(std::make_index_sequence<in_t::rank()>{})) {
-        return in;
-
-    } else if constexpr (in_t::rank() == 0) {
-        auto new_strides =
-            std::array<typename extents_t::size_type, extents_t::rank()>{};
-
-        for (size_t i = 0; i < extents_t::rank(); i++) {
-            new_strides[i] = 0;
-        }
-
-        return mdspan<typename in_t::element_type, extents_t, layout_stride,
-                      typename in_t::accessor_type>{
-            in.data_handle(), layout_stride::mapping{new_extents, new_strides}};
-
-    } else {
-        auto new_strides =
-            std::array<typename extents_t::size_type, extents_t::rank()>{};
-
-        for (size_t i = 0; i < extents_t::rank(); i++) {
-            if (i < extents_t::rank() - in_t::rank()) {
-                new_strides[i] = 0;
-
-            } else {
-                const size_t j = i - (extents_t::rank() - in_t::rank());
-
-                if (in.extent(j) == new_extents.extent(i)) {
-                    new_strides[i] = static_cast<typename extents_t::size_type>(
-                        in.stride(j));
-
-                } else if (in.extent(j) == 1) {
-                    new_strides[i] = 0;
-
-                } else {
-                    assert(false);
-                }
-            }
-        }
-
-        return mdspan<typename in_t::element_type, extents_t, layout_stride,
-                      typename in_t::accessor_type>{
-            in.data_handle(), layout_stride::mapping{new_extents, new_strides}};
-    }
-}
-
 template <size_t offset, size_t brank, mdspan_c in_t, extents_c new_bexts_t>
 [[nodiscard]] inline constexpr auto
-broadcast_to_new(const in_t &in = in_t{},
-                 const new_bexts_t &new_bexts = new_bexts_t{}) noexcept {
-    static_assert(in_t::rank() >= offset + brank, "Incompatible rank");
-    static_assert(new_bexts_t::rank() >= brank);
+broadcast_to(const in_t &in = in_t{},
+             const new_bexts_t &new_bexts = new_bexts_t{}) noexcept {
+    constexpr size_t urank = in_t::rank() - brank;
+
+    static_assert(in_t::rank() >= offset + brank,
+                  "Incompatible offset and brank for broadcasting.");
+    static_assert(new_bexts_t::rank() >= brank,
+                  "Incompatible brank for broadcasting.");
 
     if constexpr (brank == new_bexts_t::rank() &&
                   []<size_t... Is>(std::index_sequence<Is...>) {
@@ -202,8 +151,7 @@ broadcast_to_new(const in_t &in = in_t{},
         using size_type = std::common_type_t<typename in_t::size_type,
                                              typename new_bexts_t::size_type>;
 
-        auto new_strides =
-            std::array<size_type, in_t::rank() - brank + new_bexts_t::rank()>{};
+        auto new_strides = std::array<size_type, urank + new_bexts_t::rank()>{};
 
         for (size_t i = 0; i < new_strides.size(); i++) {
             if (i < offset) {
@@ -231,38 +179,32 @@ broadcast_to_new(const in_t &in = in_t{},
             }
         }
 
-        auto new_extents = concatenate(
-            slice_from_left<offset>(in.extents()), new_bexts,
-            slice_from_right<in_t::rank() - offset - brank>(in.extents()));
+        const auto new_extents = [&]() {
+            if constexpr (offset == 0) {
+                return concatenate(new_bexts,
+                                   slice_from_right<urank>(in.extents()));
 
-        return mdspan<typename in_t::element_type, decltype(new_extents),
-                      layout_stride, typename in_t::accessor_type>{
+            } else {
+                return concatenate(
+                    slice_from_left<offset>(in.extents()), new_bexts,
+                    slice_from_right<urank - offset>(in.extents()));
+            }
+        }();
+
+        return mdspan<typename in_t::element_type,
+                      std::remove_const_t<decltype(new_extents)>, layout_stride,
+                      typename in_t::accessor_type>{
             in.data_handle(), layout_stride::mapping{new_extents, new_strides}};
     }
 }
 
 namespace detail {
 
-template <size_t BatchRank, typename Func, mdspan_c in_t, mdspan_c... ins_t>
-inline constexpr void batch_impl_none(Func &&func, const in_t &in,
-                                      const ins_t &...ins) noexcept {
-    if constexpr (BatchRank == 0) {
-        std::forward<Func>(func)(in, ins...);
-
-    } else {
-        for (typename in_t::index_type i = 0; i < in.extent(0); i++) {
-            batch_impl_none<BatchRank - 1>(std::forward<Func>(func),
-                                           submdspan_from_left(in, i),
-                                           submdspan_from_left(ins, i)...);
-        }
-    }
-}
-
 template <size_t brank, typename Func, size_t offset, size_t... offsets,
           mdspan_c in_t, mdspan_c... ins_t>
 inline constexpr void
-batch_impl_none_new(Func &&func, std::index_sequence<offset, offsets...>,
-                    const in_t &in, const ins_t &...ins) noexcept {
+batch_impl_none(Func &&func, std::index_sequence<offset, offsets...>,
+                const in_t &in, const ins_t &...ins) noexcept {
     static_assert(sizeof...(offsets) == sizeof...(ins_t),
                   "Number of offsets must match number of inputs.");
 
@@ -271,7 +213,7 @@ batch_impl_none_new(Func &&func, std::index_sequence<offset, offsets...>,
 
     } else {
         for (size_t i = 0; i < in.extent(offset); i++) {
-            batch_impl_none_new<brank - 1>(
+            batch_impl_none<brank - 1>(
                 std::forward<Func>(func),
                 std::index_sequence<offset, offsets...>{},
                 submdspan_from_left<offset>(in, i),
@@ -282,27 +224,11 @@ batch_impl_none_new(Func &&func, std::index_sequence<offset, offsets...>,
 
 #ifdef _OPENMP
 
-template <size_t BatchRank, typename Func, mdspan_c in_t, mdspan_c... ins_t>
-inline constexpr void batch_impl_cpump(Func &&func, const in_t &in,
-                                       const ins_t &...ins) noexcept {
-    if constexpr (BatchRank == 0) {
-        std::forward<Func>(func)(in, ins...);
-
-    } else {
-#pragma omp parallel for
-        for (typename in_t::index_type i = 0; i < in.extent(0); i++) {
-            batch_impl_none<BatchRank - 1>(std::forward<Func>(func),
-                                           submdspan_from_left(in, i),
-                                           submdspan_from_left(ins, i)...);
-        }
-    }
-}
-
 template <size_t brank, typename Func, size_t offset, size_t... offsets,
           mdspan_c in_t, mdspan_c... ins_t>
 inline constexpr void
-batch_impl_cpump_new(Func &&func, std::index_sequence<offset, offsets...>,
-                     const in_t &in, const ins_t &...ins) noexcept {
+batch_impl_cpump(Func &&func, std::index_sequence<offset, offsets...>,
+                 const in_t &in, const ins_t &...ins) noexcept {
     static_assert(sizeof...(offsets) == sizeof...(ins_t),
                   "Number of offsets must match number of inputs.");
 
@@ -312,7 +238,7 @@ batch_impl_cpump_new(Func &&func, std::index_sequence<offset, offsets...>,
     } else {
 #pragma omp parallel for
         for (size_t i = 0; i < in.extent(offset); i++) {
-            batch_impl_none_new<brank - 1>(
+            batch_impl_none<brank - 1>(
                 std::forward<Func>(func),
                 std::index_sequence<offset, offsets...>{},
                 submdspan_from_left<offset>(in, i),
@@ -321,54 +247,20 @@ batch_impl_cpump_new(Func &&func, std::index_sequence<offset, offsets...>,
     }
 }
 
-template <typename Func, size_t uin_rank, size_t... uins_rank, mdspan_c in_t,
-          mdspan_c... ins_t>
-inline constexpr void
-batch_impl_cpump_new(Func &&func, std::index_sequence<uin_rank, uins_rank...>,
-                     const in_t &in, const ins_t &...ins) noexcept {
-    if constexpr (in_t::rank() == uin_rank) {
-        std::forward<Func>(func)(in, ins...);
-
-    } else {
-#pragma omp parallel for
-        for (typename in_t::index_type i = 0; i < in.extent(0); i++) {
-            batch_impl_none_new(std::forward<Func>(func),
-                                std::index_sequence<uin_rank, uins_rank...>{},
-                                submdspan_from_left(in, i),
-                                submdspan_from_left(ins, i)...);
-        }
-    }
-}
-
 #endif
-
-template <size_t BatchRank, typename Func, mdspan_c... ins_t>
-inline constexpr void batch_impl(Func &&func, const MPMode mpmode,
-                                 const ins_t &...ins) noexcept {
-    if (!std::is_constant_evaluated()) [[likely]] {
-        if (mpmode == MPMode::CPUMP) [[unlikely]] {
-#ifdef _OPENMP
-            batch_impl_cpump<BatchRank>(std::forward<Func>(func), ins...);
-            return;
-#else
-            assert(false);
-#endif
-        }
-    }
-
-    batch_impl_none<BatchRank>(std::forward<Func>(func), ins...);
-}
 
 template <size_t brank, typename Func, size_t... offsets, mdspan_c... ins_t>
-inline constexpr void
-batch_impl_new(Func &&func, std::index_sequence<offsets...>,
-               const MPMode mpmode, const ins_t &...ins) noexcept {
+inline constexpr void batch_impl(Func &&func, std::index_sequence<offsets...>,
+                                 const MPMode mpmode,
+                                 const ins_t &...ins) noexcept {
+    static_assert(sizeof...(offsets) == sizeof...(ins_t),
+                  "Number of offsets must match number of inputs.");
+
     if (!std::is_constant_evaluated()) [[likely]] {
         if (mpmode == MPMode::CPUMP) [[unlikely]] {
 #ifdef _OPENMP
-            batch_impl_cpump_new<brank>(std::forward<Func>(func),
-                                        std::index_sequence<offsets...>{},
-                                        ins...);
+            batch_impl_cpump<brank>(std::forward<Func>(func),
+                                    std::index_sequence<offsets...>{}, ins...);
             return;
 #else
             assert(false);
@@ -376,8 +268,8 @@ batch_impl_new(Func &&func, std::index_sequence<offsets...>,
         }
     }
 
-    batch_impl_none_new<brank>(std::forward<Func>(func),
-                               std::index_sequence<offsets...>{}, ins...);
+    batch_impl_none<brank>(std::forward<Func>(func),
+                           std::index_sequence<offsets...>{}, ins...);
 }
 
 } // namespace detail
@@ -392,197 +284,55 @@ template <typename T, extents_c exts_t>
     }
 }
 
-template <typename T = int8_t, mdspan_c... ins_t, extents_c... uinexts_t>
-    requires(sizeof...(ins_t) == sizeof...(uinexts_t) - 1)
+template <typename T = int8_t, size_t... offsets, size_t... uranks,
+          extents_c uout_exts_t, mdspan_c... ins_t>
+    requires(sizeof...(offsets) == sizeof...(ins_t) + 1 &&
+             sizeof...(uranks) == sizeof...(ins_t))
 [[nodiscard]] inline constexpr auto
-create_out(const std::tuple<ins_t...> &ins,
-           const std::tuple<uinexts_t...> &uinexts) noexcept {
+create_out(std::index_sequence<offsets...>, std::index_sequence<uranks...>,
+           const uout_exts_t &uout_exts, const ins_t &...ins) noexcept {
     using element_t = std::common_type_t<T, element_type_t<ins_t>...>;
 
-    const auto bexts = [&]<size_t... Is>(std::index_sequence<Is...>) {
-        return broadcast(
-            slice_from_left<
-                std::tuple_element_t<Is, std::tuple<ins_t...>>::rank() -
-                std::tuple_element_t<Is, std::tuple<uinexts_t...>>::rank()>(
-                std::get<Is>(ins).extents())...);
+    constexpr auto ofst = std::array{offsets...};
+    constexpr auto ur = std::array{uranks...};
+    constexpr auto br = [&]<size_t... Is>(std::index_sequence<Is...>) {
+        return std::array{
+            (std::tuple_element_t<Is, std::tuple<ins_t...>>::rank() -
+             ur[Is])...};
     }(std::make_index_sequence<sizeof...(ins_t)>{});
 
-    return create_out<element_t>(
-        core::concatenate(bexts, std::get<sizeof...(ins_t)>(uinexts)));
-}
-
-template <typename T = int8_t, size_t... offsets, size_t... branks,
-          size_t uout_offset, extents_c uout_exts_t, mdspan_c... ins_t>
-    requires(sizeof...(offsets) == sizeof...(ins_t) &&
-             sizeof...(branks) == sizeof...(ins_t))
-[[nodiscard]] inline constexpr auto
-create_out_new(std::index_sequence<offsets...>, std::index_sequence<branks...>,
-               std::integral_constant<size_t, uout_offset>,
-               const uout_exts_t &uout_exts, const ins_t &...ins) noexcept {
-    using element_t = std::common_type_t<T, element_type_t<ins_t>...>;
-
-    constexpr std::array ofst = {offsets...};
-    constexpr std::array br = {branks...};
     auto ins_tuple = std::forward_as_tuple(ins...);
 
     const auto bexts = [&]<size_t... Is>(std::index_sequence<Is...>) {
         return broadcast(slice_with_offset<ofst[Is], br[Is]>(
             std::get<Is>(ins_tuple).extents())...);
     }(std::make_index_sequence<sizeof...(ins_t)>{});
+
+    constexpr size_t uout_offset = ofst[sizeof...(ins_t)];
 
     return create_out<element_t>(core::concatenate(
         slice_from_left<uout_offset>(uout_exts), bexts,
         slice_from_right<uout_exts_t::rank() - uout_offset>(uout_exts)));
 }
 
-template <typename T = int8_t, mdspan_c... ins_t, extents_c... uinexts_t>
-    requires(sizeof...(ins_t) < sizeof...(uinexts_t) - 1)
+template <typename T = int8_t, size_t... offsets, size_t... uranks,
+          extents_c... uouts_exts_t, mdspan_c... ins_t>
+    requires(sizeof...(offsets) == sizeof...(ins_t) + sizeof...(uouts_exts_t) &&
+             sizeof...(uranks) == sizeof...(ins_t))
 [[nodiscard]] inline constexpr auto
-create_out(const std::tuple<ins_t...> &ins,
-           const std::tuple<uinexts_t...> &uinexts) noexcept {
+create_out(std::index_sequence<offsets...>, std::index_sequence<uranks...>,
+           const std::tuple<uouts_exts_t...> &uouts_exts,
+           const ins_t &...ins) noexcept {
     using element_t = std::common_type_t<T, element_type_t<ins_t>...>;
 
-    const auto bexts = [&]<size_t... Is>(std::index_sequence<Is...>) {
-        return broadcast(
-            slice_from_left<
-                std::tuple_element_t<Is, std::tuple<ins_t...>>::rank() -
-                std::tuple_element_t<Is, std::tuple<uinexts_t...>>::rank()>(
-                std::get<Is>(ins).extents())...);
+    constexpr auto ofst = std::array{offsets...};
+    constexpr auto ur = std::array{uranks...};
+    constexpr auto br = [&]<size_t... Is>(std::index_sequence<Is...>) {
+        return std::array{
+            (std::tuple_element_t<Is, std::tuple<ins_t...>>::rank() -
+             ur[Is])...};
     }(std::make_index_sequence<sizeof...(ins_t)>{});
 
-    return [&]<size_t... Is>(std::index_sequence<Is...>) {
-        return std::tuple{create_out<element_t>(core::concatenate(
-            bexts, std::get<sizeof...(ins_t) + Is>(uinexts)))...};
-    }(std::make_index_sequence<sizeof...(uinexts_t) - sizeof...(ins_t)>{});
-}
-
-template <typename Func, mdspan_c... ins_t, extents_c... uinexts_t>
-    requires(sizeof...(ins_t) == sizeof...(uinexts_t))
-inline constexpr void batch(Func &&func, const std::tuple<ins_t...> &ins,
-                            const std::tuple<uinexts_t...> &uinexts,
-                            const MPMode mpmode) noexcept {
-    constexpr bool need_batch = []<size_t... Is>(std::index_sequence<Is...>) {
-        return ((std::tuple_element_t<Is, std::tuple<ins_t...>>::rank() !=
-                 std::tuple_element_t<Is, std::tuple<uinexts_t...>>::rank()) ||
-                ...);
-    }(std::make_index_sequence<sizeof...(ins_t)>{});
-
-    if constexpr (!need_batch) {
-        // Pass directly to the function
-        std::apply(
-            [&](auto &&...elems) {
-                detail::batch_impl_none<0>(
-                    std::forward<Func>(func),
-                    std::forward<decltype(elems)>(elems)...);
-            },
-            ins);
-
-    } else {
-        constexpr bool possibly_not_bcast = []<size_t... Is>(
-                                                std::index_sequence<Is...>) {
-            constexpr size_t ref =
-                std::tuple_element_t<0, std::tuple<ins_t...>>::rank() -
-                std::tuple_element_t<0, std::tuple<uinexts_t...>>::rank();
-            return (
-                (std::tuple_element_t<Is, std::tuple<ins_t...>>::rank() -
-                     std::tuple_element_t<Is,
-                                          std::tuple<uinexts_t...>>::rank() ==
-                 ref) &&
-                ...);
-        }(std::make_index_sequence<sizeof...(ins_t)>{});
-
-        if constexpr (possibly_not_bcast) {
-            // Pass without broadcasting (less computation)
-            constexpr size_t brank =
-                std::tuple_element_t<0, std::tuple<ins_t...>>::rank() -
-                std::tuple_element_t<0, std::tuple<uinexts_t...>>::rank();
-
-            const bool same_bexts = [&]<size_t... Is>(
-                                        std::index_sequence<Is...>) {
-                return same(std::make_tuple(
-                    slice_from_left<brank>(std::get<Is>(ins).extents())...));
-            }(std::make_index_sequence<sizeof...(ins_t)>{});
-
-            if (same_bexts) [[likely]] {
-                const bool is_flattable =
-                    [&]<size_t... Is>(std::index_sequence<Is...>) {
-                        return (core::is_reshapable(std::get<Is>(ins)) && ...);
-                    }(std::make_index_sequence<sizeof...(ins_t)>{});
-
-                if (is_flattable) [[likely]] {
-                    // Flatten batch if possible (simd friendly)
-                    constexpr size_t static_bsize =
-                        static_size<decltype(slice_from_left<brank>(
-                            std::get<0>(ins).extents()))>();
-                    const size_t bsize = size(
-                        slice_from_left<brank>(std::get<0>(ins).extents()));
-
-                    const auto fins = [&]<size_t... Is>(
-                                          std::index_sequence<Is...>) {
-                        return std::tuple{reshape(
-                            std::get<Is>(ins),
-                            concatenate(extents<size_t, static_bsize>{bsize},
-                                        std::get<Is>(uinexts)))...};
-                    }(std::make_index_sequence<sizeof...(ins_t)>{});
-
-                    std::apply(
-                        [&](auto &&...elems) {
-                            detail::batch_impl<1>(
-                                std::forward<Func>(func), mpmode,
-                                std::forward<decltype(elems)>(elems)...);
-                        },
-                        fins);
-
-                } else {
-                    std::apply(
-                        [&](auto &&...elems) {
-                            detail::batch_impl<brank>(
-                                std::forward<Func>(func), mpmode,
-                                std::forward<decltype(elems)>(elems)...);
-                        },
-                        ins);
-                }
-
-                return;
-            }
-        }
-
-        // Broadcasting
-        const auto bexts = [&]<size_t... Is>(std::index_sequence<Is...>) {
-            return broadcast(
-                slice_from_left<
-                    std::tuple_element_t<Is, std::tuple<ins_t...>>::rank() -
-                    std::tuple_element_t<Is, std::tuple<uinexts_t...>>::rank()>(
-                    std::get<Is>(ins).extents())...);
-        }(std::make_index_sequence<sizeof...(ins_t)>{});
-
-        constexpr size_t brank = decltype(bexts)::rank();
-
-        const auto bins = [&]<size_t... Is>(std::index_sequence<Is...>) {
-            return std::tuple{
-                broadcast_to(std::get<Is>(ins),
-                             concatenate(bexts, std::get<Is>(uinexts)))...};
-        }(std::make_index_sequence<sizeof...(ins_t)>{});
-
-        std::apply(
-            [&](auto &&...elems) {
-                detail::batch_impl<brank>(
-                    std::forward<Func>(func), mpmode,
-                    std::forward<decltype(elems)>(elems)...);
-            },
-            bins);
-    }
-}
-
-template <typename Func, size_t... offsets, size_t... branks, mdspan_c... ins_t>
-    requires(sizeof...(offsets) == sizeof...(ins_t) &&
-             sizeof...(branks) == sizeof...(ins_t))
-inline constexpr void batch_new(Func &&func, std::index_sequence<offsets...>,
-                                std::index_sequence<branks...>,
-                                const MPMode mpmode,
-                                const ins_t &...ins) noexcept {
-    constexpr std::array ofst = {offsets...};
-    constexpr std::array br = {branks...};
     auto ins_tuple = std::forward_as_tuple(ins...);
 
     const auto bexts = [&]<size_t... Is>(std::index_sequence<Is...>) {
@@ -590,70 +340,197 @@ inline constexpr void batch_new(Func &&func, std::index_sequence<offsets...>,
             std::get<Is>(ins_tuple).extents())...);
     }(std::make_index_sequence<sizeof...(ins_t)>{});
 
-    [&]<size_t... Is>(std::index_sequence<Is...>) {
-        detail::batch_impl_new<bexts.rank()>(
-            std::forward<Func>(func), std::index_sequence<offsets...>{}, mpmode,
-            broadcast_to_new<ofst[Is], br[Is]>(std::get<Is>(ins_tuple),
+    return [&]<size_t... Is>(std::index_sequence<Is...>) {
+        return std::tuple{create_out<element_t>(core::concatenate(
+            slice_from_left<ofst[sizeof...(ins_t) + Is]>(
+                std::get<Is>(uouts_exts)),
+            bexts,
+            slice_from_right<
+                std::tuple_element_t<Is, std::tuple<uouts_exts_t...>>::rank() -
+                ofst[sizeof...(ins_t) + Is]>(std::get<Is>(uouts_exts))))...};
+    }(std::make_index_sequence<sizeof...(uouts_exts_t)>{});
+}
+
+template <typename Func, size_t... offsets, size_t... uranks, mdspan_c... ins_t>
+    requires(sizeof...(offsets) == sizeof...(ins_t) &&
+             sizeof...(uranks) == sizeof...(ins_t))
+inline constexpr void batch(Func &&func, std::index_sequence<offsets...>,
+                            std::index_sequence<uranks...>, const MPMode mpmode,
+                            const ins_t &...ins) noexcept {
+    constexpr auto ofst = std::array{offsets...};
+    constexpr auto ur = std::array{uranks...};
+    constexpr auto br = [&]<size_t... Is>(std::index_sequence<Is...>) {
+        return std::array{
+            (std::tuple_element_t<Is, std::tuple<ins_t...>>::rank() -
+             ur[Is])...};
+    }(std::make_index_sequence<sizeof...(ins_t)>{});
+
+    auto ins_tuple = std::forward_as_tuple(ins...);
+
+    constexpr bool no_branks = [&]<size_t... Is>(std::index_sequence<Is...>) {
+        return ((br[Is] == 0) && ...);
+    }(std::make_index_sequence<sizeof...(ins_t)>{});
+
+    if constexpr (no_branks) {
+        // If all branks are 0, batch is not required.
+        std::forward<Func>(func)(ins...);
+
+    } else {
+        constexpr bool possibly_same_bexts =
+            [&]<size_t... Is>(std::index_sequence<Is...>) {
+                return ((br[Is] == br[0]) && ...);
+            }(std::make_index_sequence<sizeof...(ins_t)>{});
+
+        if constexpr (possibly_same_bexts) {
+            const auto same_bexts =
+                [&]<size_t... Is>(std::index_sequence<Is...>) {
+                    return ctmd::same(slice_with_offset<ofst[Is], br[Is]>(
+                        std::get<Is>(ins_tuple).extents())...);
+                }(std::make_index_sequence<sizeof...(ins_t)>{});
+
+            if (same_bexts) [[likely]] {
+                // If all bexts are same, broadcasting is not required.
+
+                const bool is_flattable =
+                    [&]<size_t... Is>(std::index_sequence<Is...>) {
+                        return (core::is_reshapable(std::get<Is>(ins_tuple)) &&
+                                ...);
+                    }(std::make_index_sequence<sizeof...(ins_t)>{});
+
+                if (is_flattable) [[likely]] {
+                    // If flattable, reshape to use single for loop (simd
+                    // friendly)
+
+                    const auto bexts = slice_with_offset<ofst[0], br[0]>(
+                        std::get<0>(ins_tuple).extents());
+
+                    constexpr size_t static_bsize = ctmd::static_size(bexts);
+                    const size_t bsize = ctmd::size(bexts);
+
+                    [&]<size_t... Is>(std::index_sequence<Is...>) {
+                        detail::batch_impl<1>(
+                            std::forward<Func>(func),
+                            std::index_sequence<offsets...>{}, mpmode,
+                            core::reshape(
+                                std::get<Is>(ins_tuple),
+                                concatenate(
+                                    slice_from_left<ofst[Is]>(
+                                        std::get<Is>(ins_tuple).extents()),
+                                    extents<size_t, static_bsize>{bsize},
+                                    slice_from_right<
+                                        std::tuple_element_t<
+                                            Is, std::tuple<ins_t...>>::rank() -
+                                        ofst[Is] - br[Is]>(
+                                        std::get<Is>(ins_tuple)
+                                            .extents())))...);
+                    }(std::make_index_sequence<sizeof...(ins_t)>{});
+
+                } else {
+                    // If not flattable, pass to nested for loop
+                    detail::batch_impl<br[0]>(std::forward<Func>(func),
+                                              std::index_sequence<offsets...>{},
+                                              mpmode, ins...);
+                }
+
+                return;
+            }
+        }
+
+        // If all previous conditions are false, broadcasting is required.
+        const auto bexts = [&]<size_t... Is>(std::index_sequence<Is...>) {
+            return broadcast(slice_with_offset<ofst[Is], br[Is]>(
+                std::get<Is>(ins_tuple).extents())...);
+        }(std::make_index_sequence<sizeof...(ins_t)>{});
+
+        [&]<size_t... Is>(std::index_sequence<Is...>) {
+            detail::batch_impl<bexts.rank()>(
+                std::forward<Func>(func), std::index_sequence<offsets...>{},
+                mpmode,
+                broadcast_to<ofst[Is], br[Is]>(std::get<Is>(ins_tuple),
                                                bexts)...);
+        }(std::make_index_sequence<sizeof...(ins_t)>{});
+    }
+}
+
+template <typename Func, size_t... uranks, mdspan_c... ins_t>
+    requires(sizeof...(uranks) == sizeof...(ins_t))
+inline constexpr void batch(Func &&func, std::index_sequence<uranks...>,
+                            const MPMode mpmode, const ins_t &...ins) noexcept {
+    [&]<size_t... Is>(std::index_sequence<Is...>) {
+        batch(std::forward<Func>(func), std::index_sequence<((void)Is, 0)...>{},
+              std::index_sequence<uranks...>{}, mpmode, ins...);
     }(std::make_index_sequence<sizeof...(ins_t)>{});
 }
 
-template <typename T = int8_t, typename Func, mdspan_c... ins_t,
-          extents_c... uinexts_t>
-    requires(sizeof...(ins_t) == sizeof...(uinexts_t) - 1)
+template <typename T = int8_t, typename Func, size_t... offsets,
+          size_t... uranks, extents_c uout_exts_t, mdspan_c... ins_t>
+    requires(sizeof...(offsets) == sizeof...(ins_t) + 1 &&
+             sizeof...(uranks) == sizeof...(ins_t))
 [[nodiscard]] inline constexpr auto
-batch_out(Func &&func, const std::tuple<ins_t...> &ins,
-          const std::tuple<uinexts_t...> &uinexts,
-          const MPMode mpmode) noexcept {
-    auto out = create_out<T>(ins, uinexts);
+batch_out(Func &&func, std::index_sequence<offsets...>,
+          std::index_sequence<uranks...>, const uout_exts_t &uout_exts,
+          const MPMode mpmode, const ins_t &...ins) noexcept {
+    auto out =
+        create_out<T>(std::index_sequence<offsets...>{},
+                      std::index_sequence<uranks...>{}, uout_exts, ins...);
 
-    batch(std::forward<Func>(func),
-          std::tuple_cat(ins, std::make_tuple(to_mdspan(out))), uinexts,
-          mpmode);
+    batch(std::forward<Func>(func), std::index_sequence<offsets...>{},
+          std::index_sequence<uranks..., uout_exts_t::rank()>{}, mpmode, ins...,
+          core::to_mdspan(out));
 
     return out;
+}
+
+template <typename T = int8_t, typename Func, size_t... uranks,
+          extents_c uout_exts_t, mdspan_c... ins_t>
+    requires(sizeof...(uranks) == sizeof...(ins_t))
+[[nodiscard]] inline constexpr auto
+batch_out(Func &&func, std::index_sequence<uranks...>,
+          const uout_exts_t &uout_exts, const MPMode mpmode,
+          const ins_t &...ins) noexcept {
+    return [&]<size_t... Is>(std::index_sequence<Is...>) {
+        return batch_out<T>(
+            std::forward<Func>(func), std::index_sequence<((void)Is, 0)...>{},
+            std::index_sequence<uranks...>{}, uout_exts, mpmode, ins...);
+    }(std::make_index_sequence<sizeof...(ins_t) + 1>{});
 }
 
 template <typename T = int8_t, typename Func, size_t... offsets,
-          size_t... branks, size_t uout_offset, extents_c uout_exts_t,
-          mdspan_c... ins_t>
-    requires(sizeof...(offsets) == sizeof...(ins_t) &&
-             sizeof...(branks) == sizeof...(ins_t))
+          size_t... uranks, extents_c... uouts_exts_t, mdspan_c... ins_t>
+    requires(sizeof...(offsets) == sizeof...(ins_t) + sizeof...(uouts_exts_t) &&
+             sizeof...(uranks) == sizeof...(ins_t))
 [[nodiscard]] inline constexpr auto
-batch_out_new(Func &&func, std::index_sequence<offsets...>,
-              std::index_sequence<branks...>,
-              std::integral_constant<size_t, uout_offset>,
-              const uout_exts_t &uout_exts, const MPMode mpmode,
-              const ins_t &...ins) noexcept {
-    auto out = create_out_new<T>(
-        std::index_sequence<offsets...>{}, std::index_sequence<branks...>{},
-        std::integral_constant<size_t, uout_offset>{}, uout_exts, ins...);
+batch_out(Func &&func, std::index_sequence<offsets...>,
+          std::index_sequence<uranks...>,
+          const std::tuple<uouts_exts_t...> &uouts_exts, const MPMode mpmode,
+          const ins_t &...ins) noexcept {
+    auto out =
+        create_out<T>(std::index_sequence<offsets...>{},
+                      std::index_sequence<uranks...>{}, uouts_exts, ins...);
 
-    batch_new(std::forward<Func>(func),
-              std::index_sequence<offsets..., uout_offset>{},
-              std::index_sequence<branks..., std::max(branks...)>{}, mpmode,
-              ins..., core::to_mdspan(out));
+    [&]<size_t... Is>(std::index_sequence<Is...>) {
+        batch(std::forward<Func>(func), std::index_sequence<offsets...>{},
+              std::index_sequence<
+                  uranks..., std::tuple_element_t<
+                                 Is, std::tuple<uouts_exts_t...>>::rank()...>{},
+              mpmode, ins..., core::to_mdspan(std::get<Is>(out))...);
+    }(std::make_index_sequence<sizeof...(uouts_exts_t)>{});
 
     return out;
 }
 
-template <typename T = int8_t, typename Func, mdspan_c... ins_t,
-          extents_c... uinexts_t>
-    requires(sizeof...(ins_t) < sizeof...(uinexts_t) - 1)
+template <typename T = int8_t, typename Func, size_t... uranks,
+          extents_c... uouts_exts_t, mdspan_c... ins_t>
+    requires(sizeof...(uranks) == sizeof...(ins_t))
 [[nodiscard]] inline constexpr auto
-batch_out(Func &&func, const std::tuple<ins_t...> &ins,
-          const std::tuple<uinexts_t...> &uinexts,
-          const MPMode mpmode) noexcept {
-    auto outs = create_out<T>(ins, uinexts);
-
-    [&]<size_t... Is>(std::index_sequence<Is...>) {
-        batch(std::forward<Func>(func),
-              std::tuple_cat(ins,
-                             std::make_tuple(to_mdspan(std::get<Is>(outs))...)),
-              uinexts, mpmode);
-    }(std::make_index_sequence<std::tuple_size_v<decltype(outs)>>{});
-
-    return outs;
+batch_out(Func &&func, std::index_sequence<uranks...>,
+          const std::tuple<uouts_exts_t...> &uouts_exts, const MPMode mpmode,
+          const ins_t &...ins) noexcept {
+    return [&]<size_t... Is>(std::index_sequence<Is...>) {
+        return batch_out<T>(
+            std::forward<Func>(func), std::index_sequence<((void)Is, 0)...>{},
+            std::index_sequence<uranks...>{}, uouts_exts, mpmode, ins...);
+    }(std::make_index_sequence<sizeof...(ins_t) + sizeof...(uouts_exts_t)>{});
 }
 
 } // namespace core

--- a/ctmd/core/broadcast.hpp
+++ b/ctmd/core/broadcast.hpp
@@ -219,7 +219,6 @@ inline constexpr void batch_impl_cpump(Func &&func, const in_t &in,
 
 #if false // TODO: fix this
 
-
 template <size_t BatchRank, typename Func, mdspan_c in_t, mdspan_c... ins_t>
 inline constexpr void batch_impl_gpump(Func &&func, const in_t &in,
                                            const ins_t &...ins) noexcept {
@@ -241,9 +240,8 @@ inline constexpr void batch_impl_gpump(Func &&func, const in_t &in,
 #endif
 
 template <size_t BatchRank, typename Func, mdspan_c in_t, mdspan_c... ins_t>
-inline constexpr void batch_impl_new(Func &&func, const MPMode mpmode,
-                                     const in_t &in,
-                                     const ins_t &...ins) noexcept {
+inline constexpr void batch_impl(Func &&func, const MPMode mpmode,
+                                 const in_t &in, const ins_t &...ins) noexcept {
     if (!std::is_constant_evaluated()) [[likely]] {
         if (mpmode == MPMode::CPUMP) [[unlikely]] {
 #ifdef _OPENMP
@@ -381,7 +379,7 @@ inline constexpr void batch(Func &&func, const std::tuple<ins_t...> &ins,
 
                     std::apply(
                         [&](auto &&...elems) {
-                            detail::batch_impl_new<1>(
+                            detail::batch_impl<1>(
                                 std::forward<Func>(func), mpmode,
                                 std::forward<decltype(elems)>(elems)...);
                         },
@@ -390,7 +388,7 @@ inline constexpr void batch(Func &&func, const std::tuple<ins_t...> &ins,
                 } else {
                     std::apply(
                         [&](auto &&...elems) {
-                            detail::batch_impl_new<brank>(
+                            detail::batch_impl<brank>(
                                 std::forward<Func>(func), mpmode,
                                 std::forward<decltype(elems)>(elems)...);
                         },
@@ -421,7 +419,7 @@ inline constexpr void batch(Func &&func, const std::tuple<ins_t...> &ins,
 
         std::apply(
             [&](auto &&...elems) {
-                detail::batch_impl_new<brank>(
+                detail::batch_impl<brank>(
                     std::forward<Func>(func), mpmode,
                     std::forward<decltype(elems)>(elems)...);
             },

--- a/ctmd/core/convert.hpp
+++ b/ctmd/core/convert.hpp
@@ -27,7 +27,7 @@ template <typename InType>
 template <mdspan_c in_t>
 [[nodiscard]] inline constexpr auto to_const(const in_t &in) noexcept {
     if constexpr (std::is_const_v<typename in_t::element_type>) {
-        return in;
+        return std::forward<const in_t>(in);
 
     } else {
         using const_element_t = const typename in_t::element_type;

--- a/ctmd/core/submdspan.hpp
+++ b/ctmd/core/submdspan.hpp
@@ -6,30 +6,43 @@
 namespace ctmd {
 namespace core {
 
-template <mdspan_c in_t, typename... slices_t>
+template <size_t lspace, size_t rspace, mdspan_c in_t, typename... slices_t>
 [[nodiscard]] inline constexpr auto
-submdspan_from_left(const in_t &in, slices_t &&...slices) noexcept {
-    static_assert(in_t::rank() >= sizeof...(slices_t),
-                  "The number of slices must not exceed the rank of the input "
+submdspan_with_space(const in_t &in, slices_t &&...slices) noexcept {
+    static_assert(in_t::rank() == lspace + sizeof...(slices_t) + rspace,
+                  "The number of slices must match the rank of the input "
                   "mdspan.");
 
-    return [&in, &slices...]<size_t... Is>(std::index_sequence<Is...>) {
-        return ctmd::submdspan(in, std::forward<slices_t>(slices)...,
-                               ((void)Is, ctmd::full_extent)...);
-    }(std::make_index_sequence<in_t::rank() - sizeof...(slices_t)>{});
+    return [&]<size_t... Is, size_t... Js>(std::index_sequence<Is...>,
+                                           std::index_sequence<Js...>) {
+        return ctmd::submdspan(in, ((void)Is, ctmd::full_extent)...,
+                               std::forward<slices_t>(slices)...,
+                               ((void)Js, ctmd::full_extent)...);
+    }(std::make_index_sequence<lspace>{}, std::make_index_sequence<rspace>{});
 }
 
-template <mdspan_c in_t, typename... slices_t>
+template <size_t lspace = 0, mdspan_c in_t, typename... slices_t>
+[[nodiscard]] inline constexpr auto
+submdspan_from_left(const in_t &in, slices_t &&...slices) noexcept {
+    static_assert(
+        in_t::rank() >= lspace + sizeof...(slices_t),
+        "The number of slices must not exceed the rank of the input mdspan.");
+
+    constexpr size_t rspace = in_t::rank() - (lspace + sizeof...(slices_t));
+    return submdspan_with_space<lspace, rspace>(
+        in, std::forward<slices_t>(slices)...);
+}
+
+template <size_t rspace = 0, mdspan_c in_t, typename... slices_t>
 [[nodiscard]] inline constexpr auto
 submdspan_from_right(const in_t &in, slices_t &&...slices) noexcept {
-    static_assert(in_t::rank() >= sizeof...(slices_t),
-                  "The number of slices must not exceed the rank of the input "
-                  "mdspan.");
+    static_assert(
+        in_t::rank() >= rspace + sizeof...(slices_t),
+        "The number of slices must not exceed the rank of the input mdspan.");
 
-    return [&in, &slices...]<size_t... Is>(std::index_sequence<Is...>) {
-        return ctmd::submdspan(in, ((void)Is, ctmd::full_extent)...,
-                               std::forward<slices_t>(slices)...);
-    }(std::make_index_sequence<in_t::rank() - sizeof...(slices_t)>{});
+    constexpr size_t lspace = in_t::rank() - (rspace + sizeof...(slices_t));
+    return submdspan_with_space<lspace, rspace>(
+        in, std::forward<slices_t>(slices)...);
 }
 
 } // namespace core

--- a/ctmd/core/submdspan.hpp
+++ b/ctmd/core/submdspan.hpp
@@ -6,36 +6,30 @@
 namespace ctmd {
 namespace core {
 
-template <typename InType, typename... slices_t>
+template <mdspan_c in_t, typename... slices_t>
 [[nodiscard]] inline constexpr auto
-submdspan_from_left(InType &&In, slices_t &&...slices) noexcept {
-    // NOTE: use non-const rin to avoid unnecessary copies
-    auto in = to_mdspan(std::forward<InType>(In));
-
-    static_assert(decltype(in)::rank() >= sizeof...(slices_t),
+submdspan_from_left(const in_t &in, slices_t &&...slices) noexcept {
+    static_assert(in_t::rank() >= sizeof...(slices_t),
                   "The number of slices must not exceed the rank of the input "
                   "mdspan.");
 
     return [&in, &slices...]<size_t... Is>(std::index_sequence<Is...>) {
         return ctmd::submdspan(in, std::forward<slices_t>(slices)...,
                                ((void)Is, ctmd::full_extent)...);
-    }(std::make_index_sequence<decltype(in)::rank() - sizeof...(slices_t)>{});
+    }(std::make_index_sequence<in_t::rank() - sizeof...(slices_t)>{});
 }
 
-template <typename InType, typename... slices_t>
+template <mdspan_c in_t, typename... slices_t>
 [[nodiscard]] inline constexpr auto
-submdspan_from_right(InType &&In, slices_t &&...slices) noexcept {
-    // NOTE: use non-const rin to avoid unnecessary copies
-    auto in = to_mdspan(std::forward<InType>(In));
-
-    static_assert(decltype(in)::rank() >= sizeof...(slices_t),
+submdspan_from_right(const in_t &in, slices_t &&...slices) noexcept {
+    static_assert(in_t::rank() >= sizeof...(slices_t),
                   "The number of slices must not exceed the rank of the input "
                   "mdspan.");
 
     return [&in, &slices...]<size_t... Is>(std::index_sequence<Is...>) {
         return ctmd::submdspan(in, ((void)Is, ctmd::full_extent)...,
                                std::forward<slices_t>(slices)...);
-    }(std::make_index_sequence<decltype(in)::rank() - sizeof...(slices_t)>{});
+    }(std::make_index_sequence<in_t::rank() - sizeof...(slices_t)>{});
 }
 
 } // namespace core

--- a/ctmd/core/type.hpp
+++ b/ctmd/core/type.hpp
@@ -65,7 +65,8 @@ concept mdspan_c = requires {
 };
 
 template <extents_c exts_t>
-[[nodiscard]] inline constexpr size_t static_size() noexcept {
+[[nodiscard]] inline constexpr size_t
+static_size(const exts_t &exts = exts_t{}) noexcept {
     if constexpr (exts_t::rank() == 0) {
         return 0;
 
@@ -97,6 +98,11 @@ size(const exts_t &exts = exts_t{}) noexcept {
     }
 }
 
+template <extents_c in_t>
+[[nodiscard]] inline constexpr bool same(const in_t &in = in_t{}) noexcept {
+    return true;
+}
+
 template <extents_c in1_t, extents_c in2_t, extents_c... ins_t>
 [[nodiscard]] inline constexpr bool same(const in1_t &in1 = in1_t{},
                                          const in2_t &in2 = in2_t{},
@@ -126,27 +132,6 @@ template <extents_c in1_t, extents_c in2_t, extents_c... ins_t>
 
     } else {
         return true;
-    }
-}
-
-template <extents_c... ins_t>
-[[nodiscard]] inline constexpr bool
-same(const std::tuple<ins_t...> &ins) noexcept {
-    constexpr size_t ins_num =
-        std::tuple_size_v<std::remove_reference_t<decltype(ins)>>;
-
-    if constexpr (ins_num == 0) {
-        return true;
-
-    } else if constexpr (ins_num == 1) {
-        return true;
-
-    } else {
-        return std::apply(
-            [&](auto &&...elems) {
-                return same(std::forward<decltype(elems)>(elems)...);
-            },
-            ins);
     }
 }
 

--- a/ctmd/cos.hpp
+++ b/ctmd/cos.hpp
@@ -26,8 +26,7 @@ inline constexpr void cos(InType &&In, OutType &&Out,
         [](auto &&...elems) {
             detail::cos_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0>{}, mpmode, in, out);
 }
 
 template <typename InType>
@@ -39,8 +38,7 @@ cos(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::cos_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode, in);
 }
 
 } // namespace ctmd

--- a/ctmd/cos.hpp
+++ b/ctmd/cos.hpp
@@ -27,7 +27,7 @@ inline constexpr void cos(InType &&In, OutType &&Out,
             detail::cos_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename InType>
@@ -40,7 +40,7 @@ cos(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
             detail::cos_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/divide.hpp
+++ b/ctmd/divide.hpp
@@ -27,7 +27,7 @@ inline constexpr void divide(In1Type &&In1, In2Type &&In2, OutType &&Out,
         },
         std::tuple{in1, in2, out},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename In1Type, typename In2Type>
@@ -43,7 +43,7 @@ divide(In1Type &&In1, In2Type &&In2,
         },
         std::tuple{in1, in2},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/divide.hpp
+++ b/ctmd/divide.hpp
@@ -25,9 +25,7 @@ inline constexpr void divide(In1Type &&In1, In2Type &&In2, OutType &&Out,
         [](auto &&...elems) {
             detail::divide_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2, out},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0, 0>{}, mpmode, in1, in2, out);
 }
 
 template <typename In1Type, typename In2Type>
@@ -41,9 +39,8 @@ divide(In1Type &&In1, In2Type &&In2,
         [](auto &&...elems) {
             detail::divide_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode, in1,
+        in2);
 }
 
 } // namespace ctmd

--- a/ctmd/equal.hpp
+++ b/ctmd/equal.hpp
@@ -25,9 +25,7 @@ inline constexpr void equal(In1Type &&In1, In2Type &&In2, OutType &&Out,
         [](auto &&...elems) {
             detail::equal_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2, out},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0, 0>{}, mpmode, in1, in2, out);
 }
 
 template <typename In1Type, typename In2Type>
@@ -41,9 +39,8 @@ equal(In1Type &&In1, In2Type &&In2,
         [](auto &&...elems) {
             detail::equal_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode, in1,
+        in2);
 }
 
 } // namespace ctmd

--- a/ctmd/equal.hpp
+++ b/ctmd/equal.hpp
@@ -27,7 +27,7 @@ inline constexpr void equal(In1Type &&In1, In2Type &&In2, OutType &&Out,
         },
         std::tuple{in1, in2, out},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename In1Type, typename In2Type>
@@ -43,7 +43,7 @@ equal(In1Type &&In1, In2Type &&In2,
         },
         std::tuple{in1, in2},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/eye.hpp
+++ b/ctmd/eye.hpp
@@ -29,8 +29,7 @@ inline constexpr void eye(InType &&In,
         [](auto &&...elems) {
             detail::eye_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in}, std::tuple{core::slice_from_right<2>(in.extents())},
-        mpmode);
+        std::index_sequence<2>{}, mpmode, in);
 }
 
 template <typename T, extents_c extents_t>

--- a/ctmd/eye.hpp
+++ b/ctmd/eye.hpp
@@ -29,7 +29,7 @@ inline constexpr void eye(InType &&In,
         [](auto &&...elems) {
             detail::eye_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in}, std::tuple{core::slice_from_last<2>(in.extents())},
+        std::tuple{in}, std::tuple{core::slice_from_right<2>(in.extents())},
         mpmode);
 }
 

--- a/ctmd/eye.hpp
+++ b/ctmd/eye.hpp
@@ -30,7 +30,7 @@ inline constexpr void eye(InType &&In,
             detail::eye_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in}, std::tuple{core::slice_from_last<2>(in.extents())},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename T, extents_c extents_t>

--- a/ctmd/fill.hpp
+++ b/ctmd/fill.hpp
@@ -19,11 +19,10 @@ inline constexpr void fill(InType &&In, const val_t &val,
     const auto in = core::to_mdspan(std::forward<InType>(In));
 
     core::batch(
-        [](auto &&...elems) {
-            detail::fill_impl(std::forward<decltype(elems)>(elems)...);
+        [&](auto &&...elems) {
+            detail::fill_impl(std::forward<decltype(elems)>(elems)..., val);
         },
-        std::tuple{in}, std::tuple{extents<uint8_t>{}}, std::tuple{val},
-        mpmode);
+        std::tuple{in}, std::tuple{extents<uint8_t>{}}, mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/fill.hpp
+++ b/ctmd/fill.hpp
@@ -22,7 +22,7 @@ inline constexpr void fill(InType &&In, const val_t &val,
         [&](auto &&...elems) {
             detail::fill_impl(std::forward<decltype(elems)>(elems)..., val);
         },
-        std::tuple{in}, std::tuple{extents<uint8_t>{}}, mpmode);
+        std::index_sequence<0>{}, mpmode, in);
 }
 
 } // namespace ctmd

--- a/ctmd/isclose.hpp
+++ b/ctmd/isclose.hpp
@@ -28,12 +28,13 @@ inline constexpr void isclose(In1Type &&In1, In2Type &&In2, OutType &&Out,
     const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
     core::batch(
-        [](auto &&...elems) {
-            detail::isclose_impl(std::forward<decltype(elems)>(elems)...);
+        [&rtol, &atol](auto &&...elems) {
+            detail::isclose_impl(std::forward<decltype(elems)>(elems)..., rtol,
+                                 atol);
         },
         std::tuple{in1, in2, out},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{rtol, atol}, mpmode);
+        mpmode);
 }
 
 template <typename In1Type, typename In2Type>
@@ -45,12 +46,13 @@ isclose(In1Type &&In1, In2Type &&In2, const double &rtol = 1e-05,
     const auto in2 = core::to_const_mdspan(std::forward<In2Type>(In2));
 
     return core::batch_out(
-        [](auto &&...elems) {
-            detail::isclose_impl(std::forward<decltype(elems)>(elems)...);
+        [&rtol, &atol](auto &&...elems) {
+            detail::isclose_impl(std::forward<decltype(elems)>(elems)..., rtol,
+                                 atol);
         },
         std::tuple{in1, in2},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{rtol, atol}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/isclose.hpp
+++ b/ctmd/isclose.hpp
@@ -28,13 +28,11 @@ inline constexpr void isclose(In1Type &&In1, In2Type &&In2, OutType &&Out,
     const auto out = core::to_mdspan(std::forward<OutType>(Out));
 
     core::batch(
-        [&rtol, &atol](auto &&...elems) {
+        [&](auto &&...elems) {
             detail::isclose_impl(std::forward<decltype(elems)>(elems)..., rtol,
                                  atol);
         },
-        std::tuple{in1, in2, out},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0, 0>{}, mpmode, in1, in2, out);
 }
 
 template <typename In1Type, typename In2Type>
@@ -46,13 +44,12 @@ isclose(In1Type &&In1, In2Type &&In2, const double &rtol = 1e-05,
     const auto in2 = core::to_const_mdspan(std::forward<In2Type>(In2));
 
     return core::batch_out(
-        [&rtol, &atol](auto &&...elems) {
+        [&](auto &&...elems) {
             detail::isclose_impl(std::forward<decltype(elems)>(elems)..., rtol,
                                  atol);
         },
-        std::tuple{in1, in2},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode, in1,
+        in2);
 }
 
 } // namespace ctmd

--- a/ctmd/linalg/inv.hpp
+++ b/ctmd/linalg/inv.hpp
@@ -84,7 +84,7 @@ inline constexpr void inv(InType &&In, OutType &&Out,
         std::tuple{in, out},
         std::tuple{core::slice_from_last<2>(in.extents()),
                    core::slice_from_last<2>(out.extents())},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename InType>
@@ -99,7 +99,7 @@ inv(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
         std::tuple{in},
         std::tuple{core::slice_from_last<2>(in.extents()),
                    core::slice_from_last<2>(in.extents())},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace linalg

--- a/ctmd/linalg/inv.hpp
+++ b/ctmd/linalg/inv.hpp
@@ -82,8 +82,8 @@ inline constexpr void inv(InType &&In, OutType &&Out,
             detail::inv_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in, out},
-        std::tuple{core::slice_from_last<2>(in.extents()),
-                   core::slice_from_last<2>(out.extents())},
+        std::tuple{core::slice_from_right<2>(in.extents()),
+                   core::slice_from_right<2>(out.extents())},
         mpmode);
 }
 
@@ -97,8 +97,8 @@ inv(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
             detail::inv_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in},
-        std::tuple{core::slice_from_last<2>(in.extents()),
-                   core::slice_from_last<2>(in.extents())},
+        std::tuple{core::slice_from_right<2>(in.extents()),
+                   core::slice_from_right<2>(in.extents())},
         mpmode);
 }
 

--- a/ctmd/linalg/inv.hpp
+++ b/ctmd/linalg/inv.hpp
@@ -81,10 +81,7 @@ inline constexpr void inv(InType &&In, OutType &&Out,
         [](auto &&...elems) {
             detail::inv_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in, out},
-        std::tuple{core::slice_from_right<2>(in.extents()),
-                   core::slice_from_right<2>(out.extents())},
-        mpmode);
+        std::index_sequence<2, 2>{}, mpmode, in, out);
 }
 
 template <typename InType>
@@ -96,10 +93,8 @@ inv(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::inv_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in},
-        std::tuple{core::slice_from_right<2>(in.extents()),
-                   core::slice_from_right<2>(in.extents())},
-        mpmode);
+        std::index_sequence<2>{}, core::slice_from_right<2>(in.extents()),
+        mpmode, in);
 }
 
 } // namespace linalg

--- a/ctmd/linalg/matmul.hpp
+++ b/ctmd/linalg/matmul.hpp
@@ -88,9 +88,9 @@ inline constexpr void matmul(In1Type &&In1, In2Type &&In2, OutType &&Out,
             detail::matmul_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in1, in2, out},
-        std::tuple{core::slice_from_last<2>(in1.extents()),
-                   core::slice_from_last<2>(in2.extents()),
-                   core::slice_from_last<2>(out.extents())},
+        std::tuple{core::slice_from_right<2>(in1.extents()),
+                   core::slice_from_right<2>(in2.extents()),
+                   core::slice_from_right<2>(out.extents())},
         mpmode);
 }
 
@@ -101,8 +101,8 @@ matmul(In1Type &&In1, In2Type &&In2,
     const auto in1 = core::to_const_mdspan(std::forward<In1Type>(In1));
     const auto in2 = core::to_const_mdspan(std::forward<In2Type>(In2));
 
-    const auto uin1_exts = core::slice_from_last<2>(in1.extents());
-    const auto uin2_exts = core::slice_from_last<2>(in2.extents());
+    const auto uin1_exts = core::slice_from_right<2>(in1.extents());
+    const auto uin2_exts = core::slice_from_right<2>(in2.extents());
     const auto uout_exts =
         extents<std::common_type_t<typename decltype(uin1_exts)::index_type,
                                    typename decltype(uin2_exts)::index_type>,

--- a/ctmd/linalg/matmul.hpp
+++ b/ctmd/linalg/matmul.hpp
@@ -91,7 +91,7 @@ inline constexpr void matmul(In1Type &&In1, In2Type &&In2, OutType &&Out,
         std::tuple{core::slice_from_last<2>(in1.extents()),
                    core::slice_from_last<2>(in2.extents()),
                    core::slice_from_last<2>(out.extents())},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename In1Type, typename In2Type>
@@ -115,7 +115,7 @@ matmul(In1Type &&In1, In2Type &&In2,
             detail::matmul_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in1, in2}, std::tuple{uin1_exts, uin2_exts, uout_exts},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace linalg

--- a/ctmd/linalg/matmul.hpp
+++ b/ctmd/linalg/matmul.hpp
@@ -87,11 +87,7 @@ inline constexpr void matmul(In1Type &&In1, In2Type &&In2, OutType &&Out,
         [](auto &&...elems) {
             detail::matmul_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2, out},
-        std::tuple{core::slice_from_right<2>(in1.extents()),
-                   core::slice_from_right<2>(in2.extents()),
-                   core::slice_from_right<2>(out.extents())},
-        mpmode);
+        std::index_sequence<2, 2, 2>{}, mpmode, in1, in2, out);
 }
 
 template <typename In1Type, typename In2Type>
@@ -114,8 +110,7 @@ matmul(In1Type &&In1, In2Type &&In2,
         [](auto &&...elems) {
             detail::matmul_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2}, std::tuple{uin1_exts, uin2_exts, uout_exts},
-        mpmode);
+        std::index_sequence<2, 2>{}, uout_exts, mpmode, in1, in2);
 }
 
 } // namespace linalg

--- a/ctmd/linalg/matvec.hpp
+++ b/ctmd/linalg/matvec.hpp
@@ -84,11 +84,7 @@ inline constexpr void matvec(In1Type &&In1, In2Type &&In2, OutType &&Out,
         [](auto &&...elems) {
             detail::matvec_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2, out},
-        std::tuple{core::slice_from_right<2>(in1.extents()),
-                   core::slice_from_right<1>(in2.extents()),
-                   core::slice_from_right<1>(out.extents())},
-        mpmode);
+        std::index_sequence<2, 1, 1>{}, mpmode, in1, in2, out);
 }
 
 template <typename In1Type, typename In2Type>
@@ -109,8 +105,7 @@ matvec(In1Type &&In1, In2Type &&In2,
         [](auto &&...elems) {
             detail::matvec_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2}, std::tuple{uin1_exts, uin2_exts, uout_exts},
-        mpmode);
+        std::index_sequence<2, 1>{}, uout_exts, mpmode, in1, in2);
 }
 
 } // namespace linalg

--- a/ctmd/linalg/matvec.hpp
+++ b/ctmd/linalg/matvec.hpp
@@ -85,9 +85,9 @@ inline constexpr void matvec(In1Type &&In1, In2Type &&In2, OutType &&Out,
             detail::matvec_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in1, in2, out},
-        std::tuple{core::slice_from_last<2>(in1.extents()),
-                   core::slice_from_last<1>(in2.extents()),
-                   core::slice_from_last<1>(out.extents())},
+        std::tuple{core::slice_from_right<2>(in1.extents()),
+                   core::slice_from_right<1>(in2.extents()),
+                   core::slice_from_right<1>(out.extents())},
         mpmode);
 }
 
@@ -98,8 +98,8 @@ matvec(In1Type &&In1, In2Type &&In2,
     const auto in1 = core::to_const_mdspan(std::forward<In1Type>(In1));
     const auto in2 = core::to_const_mdspan(std::forward<In2Type>(In2));
 
-    const auto uin1_exts = core::slice_from_last<2>(in1.extents());
-    const auto uin2_exts = core::slice_from_last<1>(in2.extents());
+    const auto uin1_exts = core::slice_from_right<2>(in1.extents());
+    const auto uin2_exts = core::slice_from_right<1>(in2.extents());
     const auto uout_exts =
         extents<std::common_type_t<typename decltype(uin1_exts)::index_type,
                                    typename decltype(uin2_exts)::index_type>,

--- a/ctmd/linalg/matvec.hpp
+++ b/ctmd/linalg/matvec.hpp
@@ -88,7 +88,7 @@ inline constexpr void matvec(In1Type &&In1, In2Type &&In2, OutType &&Out,
         std::tuple{core::slice_from_last<2>(in1.extents()),
                    core::slice_from_last<1>(in2.extents()),
                    core::slice_from_last<1>(out.extents())},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename In1Type, typename In2Type>
@@ -110,7 +110,7 @@ matvec(In1Type &&In1, In2Type &&In2,
             detail::matvec_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in1, in2}, std::tuple{uin1_exts, uin2_exts, uout_exts},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace linalg

--- a/ctmd/linalg/norm.hpp
+++ b/ctmd/linalg/norm.hpp
@@ -45,7 +45,7 @@ inline constexpr void norm(InType &&In, OutType &&Out,
                 detail::norm_impl(std::forward<decltype(elems)>(elems)...);
             },
             std::tuple{in, out},
-            std::tuple{core::slice_from_last<1>(in.extents()),
+            std::tuple{core::slice_from_right<1>(in.extents()),
                        extents<uint8_t>{}},
             mpmode);
     }
@@ -66,7 +66,7 @@ norm(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
                 detail::norm_impl(std::forward<decltype(elems)>(elems)...);
             },
             std::tuple{in},
-            std::tuple{core::slice_from_last<1>(in.extents()),
+            std::tuple{core::slice_from_right<1>(in.extents()),
                        extents<uint8_t>{}},
             mpmode);
     }

--- a/ctmd/linalg/norm.hpp
+++ b/ctmd/linalg/norm.hpp
@@ -44,10 +44,7 @@ inline constexpr void norm(InType &&In, OutType &&Out,
             [](auto &&...elems) {
                 detail::norm_impl(std::forward<decltype(elems)>(elems)...);
             },
-            std::tuple{in, out},
-            std::tuple{core::slice_from_right<1>(in.extents()),
-                       extents<uint8_t>{}},
-            mpmode);
+            std::index_sequence<1, 0>{}, mpmode, in, out);
     }
 }
 
@@ -65,10 +62,7 @@ norm(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
             [](auto &&...elems) {
                 detail::norm_impl(std::forward<decltype(elems)>(elems)...);
             },
-            std::tuple{in},
-            std::tuple{core::slice_from_right<1>(in.extents()),
-                       extents<uint8_t>{}},
-            mpmode);
+            std::index_sequence<1>{}, ctmd::extents<uint8_t>{}, mpmode, in);
     }
 }
 

--- a/ctmd/linalg/norm.hpp
+++ b/ctmd/linalg/norm.hpp
@@ -47,7 +47,7 @@ inline constexpr void norm(InType &&In, OutType &&Out,
             std::tuple{in, out},
             std::tuple{core::slice_from_last<1>(in.extents()),
                        extents<uint8_t>{}},
-            std::tuple{}, mpmode);
+            mpmode);
     }
 }
 
@@ -68,7 +68,7 @@ norm(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
             std::tuple{in},
             std::tuple{core::slice_from_last<1>(in.extents()),
                        extents<uint8_t>{}},
-            std::tuple{}, mpmode);
+            mpmode);
     }
 }
 

--- a/ctmd/linalg/vecmat.hpp
+++ b/ctmd/linalg/vecmat.hpp
@@ -85,9 +85,9 @@ inline constexpr void vecmat(In1Type &&In1, In2Type &&In2, OutType &&Out,
             detail::vecmat_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in1, in2, out},
-        std::tuple{core::slice_from_last<1>(in1.extents()),
-                   core::slice_from_last<2>(in2.extents()),
-                   core::slice_from_last<1>(out.extents())},
+        std::tuple{core::slice_from_right<1>(in1.extents()),
+                   core::slice_from_right<2>(in2.extents()),
+                   core::slice_from_right<1>(out.extents())},
         mpmode);
 }
 
@@ -98,8 +98,8 @@ vecmat(In1Type &&In1, In2Type &&In2,
     const auto in1 = core::to_const_mdspan(std::forward<In1Type>(In1));
     const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
 
-    const auto uin1_exts = core::slice_from_last<1>(in1.extents());
-    const auto uin2_exts = core::slice_from_last<2>(in2.extents());
+    const auto uin1_exts = core::slice_from_right<1>(in1.extents());
+    const auto uin2_exts = core::slice_from_right<2>(in2.extents());
     const auto uout_exts =
         extents<std::common_type_t<typename decltype(uin1_exts)::index_type,
                                    typename decltype(uin2_exts)::index_type>,

--- a/ctmd/linalg/vecmat.hpp
+++ b/ctmd/linalg/vecmat.hpp
@@ -88,7 +88,7 @@ inline constexpr void vecmat(In1Type &&In1, In2Type &&In2, OutType &&Out,
         std::tuple{core::slice_from_last<1>(in1.extents()),
                    core::slice_from_last<2>(in2.extents()),
                    core::slice_from_last<1>(out.extents())},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename In1Type, typename In2Type>
@@ -110,7 +110,7 @@ vecmat(In1Type &&In1, In2Type &&In2,
             detail::vecmat_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in1, in2}, std::tuple{uin1_exts, uin2_exts, uout_exts},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace linalg

--- a/ctmd/linalg/vecmat.hpp
+++ b/ctmd/linalg/vecmat.hpp
@@ -84,11 +84,7 @@ inline constexpr void vecmat(In1Type &&In1, In2Type &&In2, OutType &&Out,
         [](auto &&...elems) {
             detail::vecmat_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2, out},
-        std::tuple{core::slice_from_right<1>(in1.extents()),
-                   core::slice_from_right<2>(in2.extents()),
-                   core::slice_from_right<1>(out.extents())},
-        mpmode);
+        std::index_sequence<1, 2, 1>{}, mpmode, in1, in2, out);
 }
 
 template <typename In1Type, typename In2Type>
@@ -109,8 +105,7 @@ vecmat(In1Type &&In1, In2Type &&In2,
         [](auto &&...elems) {
             detail::vecmat_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2}, std::tuple{uin1_exts, uin2_exts, uout_exts},
-        mpmode);
+        std::index_sequence<1, 2>{}, uout_exts, mpmode, in1, in2);
 }
 
 } // namespace linalg

--- a/ctmd/multiply.hpp
+++ b/ctmd/multiply.hpp
@@ -25,9 +25,7 @@ inline constexpr void multiply(In1Type &&In1, In2Type &&In2, OutType &&Out,
         [](auto &&...elems) {
             detail::multiply_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2, out},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0, 0>{}, mpmode, in1, in2, out);
 }
 
 template <typename In1Type, typename In2Type>
@@ -41,9 +39,8 @@ multiply(In1Type &&In1, In2Type &&In2,
         [](auto &&...elems) {
             detail::multiply_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode, in1,
+        in2);
 }
 
 } // namespace ctmd

--- a/ctmd/multiply.hpp
+++ b/ctmd/multiply.hpp
@@ -27,7 +27,7 @@ inline constexpr void multiply(In1Type &&In1, In2Type &&In2, OutType &&Out,
         },
         std::tuple{in1, in2, out},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename In1Type, typename In2Type>
@@ -43,7 +43,7 @@ multiply(In1Type &&In1, In2Type &&In2,
         },
         std::tuple{in1, in2},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/negative.hpp
+++ b/ctmd/negative.hpp
@@ -24,7 +24,7 @@ inline constexpr void negative(InType &&In, OutType &&Out,
             detail::negative_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename InType>
@@ -37,7 +37,7 @@ negative(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
             detail::negative_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/negative.hpp
+++ b/ctmd/negative.hpp
@@ -23,8 +23,7 @@ inline constexpr void negative(InType &&In, OutType &&Out,
         [](auto &&...elems) {
             detail::negative_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0>{}, mpmode, in, out);
 }
 
 template <typename InType>
@@ -36,8 +35,7 @@ negative(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::negative_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode, in);
 }
 
 } // namespace ctmd

--- a/ctmd/not_equal.hpp
+++ b/ctmd/not_equal.hpp
@@ -25,9 +25,7 @@ inline constexpr void not_equal(In1Type &&In1, In2Type &&In2, OutType &&Out,
         [](auto &&...elems) {
             detail::not_equal_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2, out},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0, 0>{}, mpmode, in1, in2, out);
 }
 
 template <typename In1Type, typename In2Type>
@@ -41,9 +39,8 @@ not_equal(In1Type &&In1, In2Type &&In2,
         [](auto &&...elems) {
             detail::not_equal_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode, in1,
+        in2);
 }
 
 } // namespace ctmd

--- a/ctmd/not_equal.hpp
+++ b/ctmd/not_equal.hpp
@@ -27,7 +27,7 @@ inline constexpr void not_equal(In1Type &&In1, In2Type &&In2, OutType &&Out,
         },
         std::tuple{in1, in2, out},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename In1Type, typename In2Type>
@@ -43,7 +43,7 @@ not_equal(In1Type &&In1, In2Type &&In2,
         },
         std::tuple{in1, in2},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/random/rand.hpp
+++ b/ctmd/random/rand.hpp
@@ -104,7 +104,7 @@ inline constexpr void rand(InType &&In,
         [](auto &&...elems) {
             detail::rand_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in}, std::tuple{extents<uint8_t>{}}, mpmode);
+        std::index_sequence<0>{}, mpmode, in);
 }
 
 template <floating_point_c T, extents_c exts_t = extents<size_t>>

--- a/ctmd/random/rand.hpp
+++ b/ctmd/random/rand.hpp
@@ -104,7 +104,7 @@ inline constexpr void rand(InType &&In,
         [](auto &&...elems) {
             detail::rand_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in}, std::tuple{extents<uint8_t>{}}, std::tuple{}, mpmode);
+        std::tuple{in}, std::tuple{extents<uint8_t>{}}, mpmode);
 }
 
 template <floating_point_c T, extents_c exts_t = extents<size_t>>

--- a/ctmd/sin.hpp
+++ b/ctmd/sin.hpp
@@ -26,8 +26,7 @@ inline constexpr void sin(InType &&In, OutType &&Out,
         [](auto &&...elems) {
             detail::sin_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0>{}, mpmode, in, out);
 }
 
 template <typename InType>
@@ -39,8 +38,7 @@ sin(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::sin_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode, in);
 }
 
 } // namespace ctmd

--- a/ctmd/sin.hpp
+++ b/ctmd/sin.hpp
@@ -27,7 +27,7 @@ inline constexpr void sin(InType &&In, OutType &&Out,
             detail::sin_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename InType>
@@ -40,7 +40,7 @@ sin(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
             detail::sin_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/sqrt.hpp
+++ b/ctmd/sqrt.hpp
@@ -59,8 +59,7 @@ inline constexpr void sqrt(InType &&In, OutType &&Out,
         [](auto &&...elems) {
             detail::sqrt_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0>{}, mpmode, in, out);
 }
 
 template <typename InType>
@@ -72,8 +71,7 @@ sqrt(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::sqrt_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode, in);
 }
 
 } // namespace ctmd

--- a/ctmd/sqrt.hpp
+++ b/ctmd/sqrt.hpp
@@ -60,7 +60,7 @@ inline constexpr void sqrt(InType &&In, OutType &&Out,
             detail::sqrt_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename InType>
@@ -73,7 +73,7 @@ sqrt(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
             detail::sqrt_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/subtract.hpp
+++ b/ctmd/subtract.hpp
@@ -25,9 +25,7 @@ inline constexpr void subtract(In1Type &&In1, In2Type &&In2, OutType &&Out,
         [](auto &&...elems) {
             detail::subtract_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2, out},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0, 0>{}, mpmode, in1, in2, out);
 }
 
 template <typename In1Type, typename In2Type>
@@ -41,9 +39,8 @@ subtract(In1Type &&In1, In2Type &&In2,
         [](auto &&...elems) {
             detail::subtract_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in1, in2},
-        std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode, in1,
+        in2);
 }
 
 } // namespace ctmd

--- a/ctmd/subtract.hpp
+++ b/ctmd/subtract.hpp
@@ -27,7 +27,7 @@ inline constexpr void subtract(In1Type &&In1, In2Type &&In2, OutType &&Out,
         },
         std::tuple{in1, in2, out},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename In1Type, typename In2Type>
@@ -43,7 +43,7 @@ subtract(In1Type &&In1, In2Type &&In2,
         },
         std::tuple{in1, in2},
         std::tuple{extents<uint8_t>{}, extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/sum.hpp
+++ b/ctmd/sum.hpp
@@ -36,8 +36,8 @@ inline constexpr void sum(InType &&In, OutType &&Out,
             detail::sum_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in, out},
-        std::tuple{core::slice_from_last<rin_rank>(in.extents()),
-                   core::slice_from_last<rin_rank - 1>(out.extents())},
+        std::tuple{core::slice_from_right<rin_rank>(in.extents()),
+                   core::slice_from_right<rin_rank - 1>(out.extents())},
         mpmode);
 }
 
@@ -57,8 +57,8 @@ sum(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
             detail::sum_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in},
-        std::tuple{core::slice_from_last<rin_rank>(in.extents()),
-                   core::slice_from_last<rin_rank - 1>(in.extents())},
+        std::tuple{core::slice_from_right<rin_rank>(in.extents()),
+                   core::slice_from_right<rin_rank - 1>(in.extents())},
         mpmode);
 }
 

--- a/ctmd/sum.hpp
+++ b/ctmd/sum.hpp
@@ -35,10 +35,7 @@ inline constexpr void sum(InType &&In, OutType &&Out,
         [](auto &&...elems) {
             detail::sum_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in, out},
-        std::tuple{core::slice_from_right<rin_rank>(in.extents()),
-                   core::slice_from_right<rin_rank - 1>(out.extents())},
-        mpmode);
+        std::index_sequence<rin_rank, rin_rank - 1>{}, mpmode, in, out);
 }
 
 template <int64_t Axis, typename InType>
@@ -56,10 +53,8 @@ sum(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::sum_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in},
-        std::tuple{core::slice_from_right<rin_rank>(in.extents()),
-                   core::slice_from_right<rin_rank - 1>(in.extents())},
-        mpmode);
+        std::index_sequence<rin_rank>{},
+        core::slice_from_right<rin_rank - 1>(in.extents()), mpmode, in);
 }
 
 } // namespace ctmd

--- a/ctmd/sum.hpp
+++ b/ctmd/sum.hpp
@@ -38,7 +38,7 @@ inline constexpr void sum(InType &&In, OutType &&Out,
         std::tuple{in, out},
         std::tuple{core::slice_from_last<rin_rank>(in.extents()),
                    core::slice_from_last<rin_rank - 1>(out.extents())},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <int64_t Axis, typename InType>
@@ -59,7 +59,7 @@ sum(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
         std::tuple{in},
         std::tuple{core::slice_from_last<rin_rank>(in.extents()),
                    core::slice_from_last<rin_rank - 1>(in.extents())},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/tan.hpp
+++ b/ctmd/tan.hpp
@@ -26,8 +26,7 @@ inline constexpr void tan(InType &&In, OutType &&Out,
         [](auto &&...elems) {
             detail::tan_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0, 0>{}, mpmode, in, out);
 }
 
 template <typename InType>
@@ -39,8 +38,7 @@ tan(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::tan_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        mpmode);
+        std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode, in);
 }
 
 } // namespace ctmd

--- a/ctmd/tan.hpp
+++ b/ctmd/tan.hpp
@@ -27,7 +27,7 @@ inline constexpr void tan(InType &&In, OutType &&Out,
             detail::tan_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in, out}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 template <typename InType>
@@ -40,7 +40,7 @@ tan(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
             detail::tan_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::tuple{in}, std::tuple{extents<uint8_t>{}, extents<uint8_t>{}},
-        std::tuple{}, mpmode);
+        mpmode);
 }
 
 } // namespace ctmd


### PR DESCRIPTION
This pull request introduces a series of changes to improve the consistency, performance, and readability of the `ctmd` library's functions and utilities. The most notable changes include replacing `std::tuple` with `std::index_sequence` for argument handling in batch operations, enhancing slicing utilities, and refining type handling in the library's core components.

### Batch Operation Refactor
* Replaced `std::tuple` with `std::index_sequence` for specifying indices in batch operations across multiple files, including `abs.hpp`, `add.hpp`, `atan2.hpp`, `clip.hpp`, `cos.hpp`, `divide.hpp`, `equal.hpp`, `fill.hpp`, `isclose.hpp`, and `inv.hpp`. This change simplifies the code and improves performance by reducing unnecessary object creation. [[1]](diffhunk://#diff-f48e311d90a9bd8b7294b88978345cf9ab36ccb194e7f3c795490fcf2f42f6bcL35-R35) [[2]](diffhunk://#diff-c9994732d1e6002884a7013c301398a806166350d007f6a41f26487c54e48f20L28-R28) [[3]](diffhunk://#diff-92a1648264edfaada2ef3fc9e753431662713f50d60dd4eebd760f33234cf49dL34-R34) [[4]](diffhunk://#diff-5756e30dae44a8d7449b13438e9947cdf16b2b4495bfa5bcf96824a43ad0e9b2L34-R34) [[5]](diffhunk://#diff-17cb1195c19519259a657dda7fffdccf4f8f77a93b7f57a3ea7596d79196f30bL29-R29) [[6]](diffhunk://#diff-9e21edfeacd67bf2681c5c915acf54197f1b6eba1f93c09da8f30d2c7708ab98L28-R28) [[7]](diffhunk://#diff-6da32ce63be03c48085ff58b9d27eb5d346d49ddc2eab91ab9d2b41ddb254b67L28-R28) [[8]](diffhunk://#diff-7333a695f0aa91601c9f56e921b5ac1020a805da6d377955a46ed8844212404aL22-R25) [[9]](diffhunk://#diff-a47cf13e0eae228fd38f8af6114f8dbe535c9475ae37f2f115f4ccbcecca4036L31-R35) [[10]](diffhunk://#diff-8448c735a7fce26212bfcf8b45629dd37c2f56e3127f0ae566fbd8c19f7030beL84-R84)

### Slicing Utilities Enhancement
* Refactored slicing utilities in `submdspan.hpp` to introduce `submdspan_with_space`, `submdspan_from_left`, and `submdspan_from_right` functions. These changes improve flexibility and clarity in slicing operations by explicitly handling left and right spaces in multidimensional arrays.

### Type Handling Improvements
* Enhanced type handling in `type.hpp` by adding a default parameter to `static_size` for better usability and introducing a simplified `same` function for single extents. Removed redundant overloads of `same` for tuples, streamlining the code. [[1]](diffhunk://#diff-20a574027b5b74a923888abc1118619c5a3c8887e9d67f38fa8e69e503c7e216L68-R69) [[2]](diffhunk://#diff-20a574027b5b74a923888abc1118619c5a3c8887e9d67f38fa8e69e503c7e216R101-R105) [[3]](diffhunk://#diff-20a574027b5b74a923888abc1118619c5a3c8887e9d67f38fa8e69e503c7e216L132-L152)

### General Refinements
* Updated `convert.hpp` to use `std::forward` for constant types, ensuring better adherence to modern C++ practices and avoiding unnecessary copies.
* Adjusted `array_equal.hpp` to use the `ctmd::array_equal` function, improving consistency across the library.

These changes collectively enhance the library's maintainability, efficiency, and alignment with modern C++ standards.