### PR TITLE
clang depressed

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,10 +2,6 @@ build --action_env=BAZEL_CXXOPTS="-std=c++23"
 run --action_env=BAZEL_CXXOPTS="-std=c++23"
 test --action_env=BAZEL_CXXOPTS="-std=c++23"
 
-# build --repo_env=CC=clang
-# run --repo_env=CC=clang
-# test --repo_env=CC=clang
-
 build --compilation_mode=opt
 run --compilation_mode=opt
 test --compilation_mode=opt

--- a/.devcontainer/DockerFile
+++ b/.devcontainer/DockerFile
@@ -15,26 +15,12 @@ RUN apt-get update && \
 RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
     apt-get update
 
-# Install gcc 13 and g++ 13
+# Install gcc 13
 RUN apt-get install -y gcc-13 g++-13 && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13
 
-# Add LLVM official repository for Clang 17
-RUN wget https://apt.llvm.org/llvm.sh && \
-    chmod +x llvm.sh && \
-    ./llvm.sh 17 && \
-    rm llvm.sh
-
-# Set Clang 17 as the default compiler
-RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang-17 100 && \
-    update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-17 100 && \
-    update-alternatives --set cc /usr/bin/clang-17 && \
-    update-alternatives --set c++ /usr/bin/clang++-17
-
-RUN ln -s /usr/bin/clang-17 /usr/bin/clang && \
-    ln -s /usr/bin/clang++-17 /usr/bin/clang++
-
-RUN apt-get update && apt-get install -y libomp-17-dev
+# Install openmp
+RUN apt-get install -y libomp-dev
 
 # Install Bazelisk
 RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64 -o /usr/local/bin/bazel && \

--- a/ctmd/core/broadcast.hpp
+++ b/ctmd/core/broadcast.hpp
@@ -222,7 +222,7 @@ batch_impl_none(Func &&func, std::index_sequence<offset, offsets...>,
     }
 }
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && defined(REAL_GCC)
 
 template <size_t brank, typename Func, size_t offset, size_t... offsets,
           mdspan_c in_t, mdspan_c... ins_t>
@@ -258,7 +258,8 @@ inline constexpr void batch_impl(Func &&func, std::index_sequence<offsets...>,
 
     if (!std::is_constant_evaluated()) [[likely]] {
         if (mpmode == MPMode::CPUMP) [[unlikely]] {
-#ifdef _OPENMP
+// TODO: use cpump in clang
+#if defined(_OPENMP) && defined(REAL_GCC)
             batch_impl_cpump<brank>(std::forward<Func>(func),
                                     std::index_sequence<offsets...>{}, ins...);
             return;


### PR DESCRIPTION
This pull request includes changes to streamline the build configuration and improve compatibility with specific compilers. The most notable updates involve removing Clang-specific settings, adjusting OpenMP usage, and refining compiler flags for GCC. Below is a breakdown of the key changes grouped by theme:

### Build Configuration Updates:
* [`.bazelrc`](diffhunk://#diff-544556920c45b42cbfe40159b082ce8af6bd929e492d076769226265f215832fL5-L8): Removed the commented-out Clang-related environment settings (`repo_env=CC=clang`) to simplify the configuration and focus on GCC-based builds.

### Development Environment Adjustments:
* [`.devcontainer/DockerFile`](diffhunk://#diff-c7503111f4faee9c731e6fcb92aaa43c9058db3527e67e4002d281e6b6735099L18-R23): Removed Clang 17 installation and configuration steps, focusing instead on GCC 13 as the default compiler. Updated OpenMP installation to use the generic `libomp-dev` package.

### Compiler Compatibility Improvements:
* [`ctmd/core/broadcast.hpp`](diffhunk://#diff-dc6cef58ae7cb2fd5532008043b6ed5719dbebc87d1d5ebb82e04f5b30c34b08L225-R225): Modified preprocessor directives to ensure OpenMP-related functionality is only enabled when using GCC (`REAL_GCC`), improving compatibility and avoiding issues with Clang. [[1]](diffhunk://#diff-dc6cef58ae7cb2fd5532008043b6ed5719dbebc87d1d5ebb82e04f5b30c34b08L225-R225) [[2]](diffhunk://#diff-dc6cef58ae7cb2fd5532008043b6ed5719dbebc87d1d5ebb82e04f5b30c34b08L261-R262)