### PR TITLE
Feature random uniform

### DIFF
--- a/ctmd/random/rand.hpp
+++ b/ctmd/random/rand.hpp
@@ -106,7 +106,7 @@ inline constexpr void rand(InType &&In,
         std::index_sequence<0>{}, mpmode, in);
 }
 
-template <floating_point_c T, extents_c exts_t = extents<size_t>>
+template <floating_point_c T = float, extents_c exts_t = extents<uint8_t, 1>>
 [[nodiscard]] inline constexpr auto
 rand(const exts_t &exts = exts_t{},
      const MPMode mpmode = MPMode::NONE) noexcept {

--- a/ctmd/random/random.hpp
+++ b/ctmd/random/random.hpp
@@ -1,3 +1,4 @@
 #pragma once
 
 #include "rand.hpp"
+#include "uniform.hpp"

--- a/ctmd/random/uniform.hpp
+++ b/ctmd/random/uniform.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "../add.hpp"
+#include "../multiply.hpp"
+#include "rand.hpp"
+
+namespace ctmd {
+namespace random {
+
+template <typename InType>
+inline constexpr void uniform(InType &&In, const double &low = 0,
+                              const double &high = 1,
+                              const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in = core::to_mdspan(std::forward<InType>(In));
+
+    using T = typename decltype(in)::value_type;
+
+    random::rand(in, mpmode);
+
+    if (mpmode == MPMode::SIMD) [[unlikely]] {
+        ctmd::multiply(in, static_cast<const T>(high - low), in);
+        ctmd::add(in, static_cast<const T>(low), in);
+        return;
+    }
+
+    core::batch(
+        [&](auto &&in) {
+            in() = static_cast<const T>(high - low) * in() +
+                   static_cast<const T>(low);
+        },
+        std::index_sequence<0>{}, mpmode, in);
+}
+
+template <floating_point_c T = float, extents_c exts_t = extents<uint8_t, 1>>
+[[nodiscard]] inline constexpr auto
+uniform(const exts_t &exts = exts_t{}, const double &low = 0,
+        const double &high = 1, const MPMode mpmode = MPMode::NONE) noexcept {
+    auto out = empty<T>(exts);
+    uniform(out, low, high, mpmode);
+    return out;
+}
+
+} // namespace random
+} // namespace ctmd

--- a/tests/random/uniform/BUILD.bazel
+++ b/tests/random/uniform/BUILD.bazel
@@ -1,0 +1,17 @@
+cc_test(
+    name = "main",
+    srcs = [
+        "main.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@gtest//:gtest_main",
+        "//:ctmd",
+    ],
+)

--- a/tests/random/uniform/main.cpp
+++ b/tests/random/uniform/main.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+#include "ctmd/array_equiv.hpp"
+#include "ctmd/random/uniform.hpp"
+#include "ctmd/to_string.hpp"
+
+namespace md = ctmd;
+
+TEST(stack, 1) {
+    using T = double;
+
+    constexpr auto out =
+        md::random::uniform<T>(md::extents<size_t, 2, 2>{}, -1, 1);
+
+    std::cout << md::to_string(out) << std::endl;
+
+    ASSERT_TRUE(!md::array_equiv(out, 0));
+}
+
+TEST(stack, 2) {
+    using T = double;
+
+    constexpr auto out =
+        md::random::uniform<T>(md::extents<size_t, 1>{}, -1, 1);
+
+    std::cout << md::to_string(out) << std::endl;
+
+    ASSERT_TRUE(!md::array_equiv(out, 0));
+}
+
+TEST(heap, 1) {
+    using T = double;
+
+    const auto out = md::random::uniform<T>(md::dims<2>{2, 2}, -1, 1);
+
+    std::cout << md::to_string(out) << std::endl;
+
+    ASSERT_TRUE(!md::array_equiv(out, 0));
+}
+
+TEST(heap, 2) {
+    using T = double;
+
+    const auto out = md::random::uniform<T>(md::dims<1>{1}, -1, 1);
+
+    std::cout << md::to_string(out) << std::endl;
+
+    ASSERT_TRUE(!md::array_equiv(out, 0));
+}


### PR DESCRIPTION
This pull request introduces a new `uniform` random number generation function in the `ctmd::random` namespace, along with updates to support it. It includes changes to the `rand` function template, the addition of a new `uniform.hpp` file, and corresponding unit tests to validate the functionality.

### Additions and Updates to Random Number Generation:

* **New `uniform` Functionality**: Added `uniform` functions to generate random numbers within a specified range (`low` to `high`) using the `MPMode` for parallelization. This includes both in-place and return-value variants. (`ctmd/random/uniform.hpp`, [ctmd/random/uniform.hppR1-R44](diffhunk://#diff-822bf53fa1efed541fc596aceaa3508d9d954971c76597f7b70ff52874286f05R1-R44))

* **Updates to `rand` Function Template**: Modified the `rand` function template to use default template arguments (`float` and `extents<uint8_t, 1>`), simplifying its usage. (`ctmd/random/rand.hpp`, [ctmd/random/rand.hppL109-R109](diffhunk://#diff-3fada3ddba12281abd38295bbfa18ec1a12720ec9313912a283279f6264074c2L109-R109))

### Integration and Testing:

* **Header Inclusion**: Added `#include "uniform.hpp"` in `random.hpp` to integrate the new `uniform` functionality into the library. (`ctmd/random/random.hpp`, [ctmd/random/random.hppR4](diffhunk://#diff-23a97598e09fa8cc257aef23f7a15dade457f44f121820e24052569a0bf8841eR4))

* **Unit Tests for `uniform`**: Introduced a new Bazel test target and test cases for the `uniform` function. These tests validate both stack- and heap-allocated scenarios with different dimensions and ranges. (`tests/random/uniform/BUILD.bazel`, [[1]](diffhunk://#diff-102d3512a63d505abe016286abf609ea392a932b196134501b23b7af95665837R1-R17); `tests/random/uniform/main.cpp`, [[2]](diffhunk://#diff-37662a1c8d1cafbf670bbf765f4b54cb36f12a002c2c15c5f6a3a303f01a4439R1-R49)