### PR TITLE
fix to_string for rank 0 mdspan

### DIFF
--- a/ctmd/to_string.hpp
+++ b/ctmd/to_string.hpp
@@ -10,7 +10,7 @@ template <mdspan_c in_t>
     std::string str = "[";
 
     if constexpr (in_t::rank() == 0) {
-        // do nothing
+        return std::to_string(in());
 
     } else if constexpr (in_t::rank() == 1) {
         for (typename in_t::size_type i = 0; i < in.extent(0); i++) {

--- a/tests/to_string/main.cpp
+++ b/tests/to_string/main.cpp
@@ -4,7 +4,13 @@
 
 namespace md = ctmd;
 
-TEST(stack, to_string) {
+TEST(stack, single) {
+    constexpr int a = 2;
+
+    ASSERT_TRUE(md::to_string(a) == "2");
+}
+
+TEST(stack, mdarray) {
     constexpr auto a = md::mdarray<int, md::extents<size_t, 2, 1, 2>>{
         std::array<int, 4>{1, 2, 3, 4}};
 
@@ -12,7 +18,7 @@ TEST(stack, to_string) {
     ASSERT_TRUE(md::to_string(a.extents()) == "(2, 1, 2)");
 }
 
-TEST(heap, to_string) {
+TEST(heap, mdarray) {
     const auto a = md::mdarray<int, md::dims<3>>{std::vector<int>{1, 2, 3, 4},
                                                  md::dims<3>{2, 1, 2}};
 


### PR DESCRIPTION
This pull request updates the `to_string` functionality in the `ctmd` library and enhances test coverage for its behavior. The most important changes include modifying the `to_string` implementation for rank-0 `mdspan` objects and restructuring the test suite to add new test cases and improve clarity.

### Changes to `to_string` implementation:

* Updated `to_string` in `ctmd/to_string.hpp` to handle rank-0 `mdspan` objects by returning the scalar value directly as a string instead of doing nothing.

### Improvements to test coverage:

* Added a new test case `stack.single` in `tests/to_string/main.cpp` to verify the `to_string` output for scalar values.
* Renamed and reorganized existing test cases in `tests/to_string/main.cpp` for better clarity, including splitting the `stack.to_string` and `heap.to_string` tests into separate `mdarray` tests.