### PR TITLE
Hotfix nullopt

### DIFF
--- a/ctmd/clip.hpp
+++ b/ctmd/clip.hpp
@@ -10,10 +10,16 @@ template <mdspan_c in_t, mdspan_c min_t, mdspan_c max_t, mdspan_c out_t>
              out_t::rank() == 0)
 inline constexpr void clip_impl(const in_t &in, const min_t &min,
                                 const max_t &max, const out_t &out) noexcept {
-    using value_t = typename in_t::value_type;
+    // NOTE: std::clamp is not used to match the behavior with original np.clip
+    out() = in();
 
-    out() = std::clamp(in(), static_cast<value_t>(min()),
-                       static_cast<value_t>(max()));
+    if constexpr (!std::is_same_v<typename min_t::value_type, std::nullopt_t>) {
+        out() = std::max(out(), static_cast<typename out_t::value_type>(min()));
+    }
+
+    if constexpr (!std::is_same_v<typename max_t::value_type, std::nullopt_t>) {
+        out() = std::min(out(), static_cast<typename out_t::value_type>(max()));
+    }
 }
 
 } // namespace detail

--- a/ctmd/core/broadcast.hpp
+++ b/ctmd/core/broadcast.hpp
@@ -292,7 +292,10 @@ template <typename T = int8_t, size_t... offsets, size_t... uranks,
 [[nodiscard]] inline constexpr auto
 create_out(std::index_sequence<offsets...>, std::index_sequence<uranks...>,
            const uout_exts_t &uout_exts, const ins_t &...ins) noexcept {
-    using value_t = std::common_type_t<T, value_type_t<ins_t>...>;
+    using value_t = std::common_type_t<
+        T,
+        std::conditional_t<std::is_same_v<value_type_t<ins_t>, std::nullopt_t>,
+                           T, value_type_t<ins_t>>...>;
 
     constexpr auto ofst = std::array{offsets...};
     constexpr auto ur = std::array{uranks...};

--- a/tests/clip/main.cpp
+++ b/tests/clip/main.cpp
@@ -1,9 +1,40 @@
 #include <gtest/gtest.h>
 
+#include "ctmd/array_equal.hpp"
 #include "ctmd/clip.hpp"
 #include "ctmd/random/rand.hpp"
 
 namespace md = ctmd;
+
+TEST(test, 1) {
+    using T = double;
+
+    constexpr T in = 1.5;
+
+    static_assert(md::clip(in, 1, 2) == 1.5);
+    static_assert(md::clip(in, 2, 3) == 2);
+    static_assert(md::clip(in, 0, 1) == 1);
+    static_assert(md::clip(in, 2, std::nullopt) == 2);
+    static_assert(md::clip(in, std::nullopt, 1) == 1);
+    static_assert(md::clip(in, std::nullopt, std::nullopt) == 1.5);
+}
+
+TEST(test, 2) {
+    using T = double;
+
+    constexpr auto in = md::mdarray<T, md::extents<size_t, 10>>{
+        std::array<T, 10>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}};
+
+    static_assert(
+        md::array_equal(md::clip(in, 1, 8),
+                        md::mdarray<T, md::extents<size_t, 10>>{
+                            std::array<T, 10>{1, 1, 2, 3, 4, 5, 6, 7, 8, 8}}));
+
+    static_assert(
+        md::array_equal(md::clip(in, 8, 1),
+                        md::mdarray<T, md::extents<size_t, 10>>{
+                            std::array<T, 10>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}}));
+}
 
 TEST(stack, clip) {
     using T = double;


### PR DESCRIPTION
This pull request introduces enhancements and fixes to the `clip` functionality in the `ctmd` library, ensuring better compatibility with optional bounds (`std::nullopt`) and adding comprehensive tests for validation. The changes also improve type handling in broadcasting operations.

### Changes to `clip` functionality:

* Updated `clip_impl` in `ctmd/clip.hpp` to handle optional bounds (`std::nullopt`) for `min` and `max` values. This ensures `std::clamp` is not used, aligning behavior with the original `np.clip`. The implementation now explicitly checks and applies bounds only when they are not `std::nullopt`.

### Improvements to type handling:

* Modified `create_out` in `ctmd/core/broadcast.hpp` to use `std::conditional_t` for handling cases where input types might be `std::nullopt_t`. This ensures proper type deduction when broadcasting operations involve optional values.

### Testing enhancements:

* Added new test cases in `tests/clip/main.cpp` to validate the `clip` functionality, including scenarios with scalar and array inputs, and combinations of optional and non-optional bounds. These tests ensure correctness and edge case handling.