### PR TITLE
Feature maximum minimum

### DIFF
--- a/ctmd/ctmd.hpp
+++ b/ctmd/ctmd.hpp
@@ -27,6 +27,8 @@
 #include "linspace.hpp"
 #include "matmul.hpp"
 #include "matvec.hpp"
+#include "maximum.hpp"
+#include "minimum.hpp"
 #include "multiply.hpp"
 #include "negative.hpp"
 #include "not_equal.hpp"

--- a/ctmd/maximum.hpp
+++ b/ctmd/maximum.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "core/core.hpp"
+
+namespace ctmd {
+namespace detail {
+
+template <mdspan_c in1_t, mdspan_c in2_t, mdspan_c out_t>
+    requires(in1_t::rank() == 0 && in2_t::rank() == 0 && out_t::rank() == 0)
+inline constexpr void maximum_impl(const in1_t &in1, const in2_t &in2,
+                                   const out_t &out) noexcept {
+    out() = std::max(static_cast<typename out_t::value_type>(in1()),
+                     static_cast<typename out_t::value_type>(in2()));
+}
+
+} // namespace detail
+
+template <typename In1Type, typename In2Type, typename OutType>
+inline constexpr void maximum(In1Type &&In1, In2Type &&In2, OutType &&Out,
+                              const MPMode mpmode = MPMode::NONE) noexcept {
+    core::batch(
+        [](auto &&...elems) {
+            detail::maximum_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::index_sequence<0, 0, 0>{}, mpmode,
+        core::to_const_mdspan(std::forward<In1Type>(In1)),
+        core::to_const_mdspan(std::forward<In2Type>(In2)),
+        core::to_mdspan(std::forward<OutType>(Out)));
+}
+
+template <typename In1Type, typename In2Type>
+[[nodiscard]] inline constexpr auto
+maximum(In1Type &&In1, In2Type &&In2,
+        const MPMode mpmode = MPMode::NONE) noexcept {
+    return core::batch_out(
+        [](auto &&...elems) {
+            detail::maximum_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        core::to_const_mdspan(std::forward<In1Type>(In1)),
+        core::to_const_mdspan(std::forward<In2Type>(In2)));
+}
+
+} // namespace ctmd

--- a/ctmd/minimum.hpp
+++ b/ctmd/minimum.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "core/core.hpp"
+
+namespace ctmd {
+namespace detail {
+
+template <mdspan_c in1_t, mdspan_c in2_t, mdspan_c out_t>
+    requires(in1_t::rank() == 0 && in2_t::rank() == 0 && out_t::rank() == 0)
+inline constexpr void minimum_impl(const in1_t &in1, const in2_t &in2,
+                                   const out_t &out) noexcept {
+    out() = std::min(static_cast<typename out_t::value_type>(in1()),
+                     static_cast<typename out_t::value_type>(in2()));
+}
+
+} // namespace detail
+
+template <typename In1Type, typename In2Type, typename OutType>
+inline constexpr void minimum(In1Type &&In1, In2Type &&In2, OutType &&Out,
+                              const MPMode mpmode = MPMode::NONE) noexcept {
+    core::batch(
+        [](auto &&...elems) {
+            detail::minimum_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::index_sequence<0, 0, 0>{}, mpmode,
+        core::to_const_mdspan(std::forward<In1Type>(In1)),
+        core::to_const_mdspan(std::forward<In2Type>(In2)),
+        core::to_mdspan(std::forward<OutType>(Out)));
+}
+
+template <typename In1Type, typename In2Type>
+[[nodiscard]] inline constexpr auto
+minimum(In1Type &&In1, In2Type &&In2,
+        const MPMode mpmode = MPMode::NONE) noexcept {
+    return core::batch_out(
+        [](auto &&...elems) {
+            detail::minimum_impl(std::forward<decltype(elems)>(elems)...);
+        },
+        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        core::to_const_mdspan(std::forward<In1Type>(In1)),
+        core::to_const_mdspan(std::forward<In2Type>(In2)));
+}
+
+} // namespace ctmd

--- a/tests/maximum/BUILD.bazel
+++ b/tests/maximum/BUILD.bazel
@@ -1,0 +1,17 @@
+cc_test(
+    name = "main",
+    srcs = [
+        "main.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@gtest//:gtest_main",
+        "//:ctmd",
+    ],
+)

--- a/tests/maximum/main.cpp
+++ b/tests/maximum/main.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+
+#include "ctmd/array_equal.hpp"
+#include "ctmd/eye.hpp"
+#include "ctmd/maximum.hpp"
+
+namespace md = ctmd;
+
+TEST(test, 1) {
+    using T = double;
+
+    static_assert(md::array_equal(
+        md::maximum(
+            md::mdarray<T, md::extents<size_t, 3>>{std::array<T, 3>{2, 3, 4}},
+            md::mdarray<T, md::extents<size_t, 3>>{std::array<T, 3>{1, 5, 2}}),
+        md::mdarray<T, md::extents<size_t, 3>>{std::array<T, 3>{2, 5, 4}}));
+
+    static_assert(
+        md::array_equal(md::maximum(md::eye<T, md::extents<size_t, 2, 2>>(),
+                                    md::mdarray<T, md::extents<size_t, 2>>{
+                                        std::array<T, 2>{0.5, 2}}),
+                        md::mdarray<T, md::extents<size_t, 2, 2>>{
+                            std::array<T, 4>{1, 2, 0.5, 2}}));
+}

--- a/tests/minimum/BUILD.bazel
+++ b/tests/minimum/BUILD.bazel
@@ -1,0 +1,17 @@
+cc_test(
+    name = "main",
+    srcs = [
+        "main.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@gtest//:gtest_main",
+        "//:ctmd",
+    ],
+)

--- a/tests/minimum/main.cpp
+++ b/tests/minimum/main.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+
+#include "ctmd/array_equal.hpp"
+#include "ctmd/eye.hpp"
+#include "ctmd/minimum.hpp"
+
+namespace md = ctmd;
+
+TEST(test, 1) {
+    using T = double;
+
+    static_assert(md::array_equal(
+        md::minimum(
+            md::mdarray<T, md::extents<size_t, 3>>{std::array<T, 3>{2, 3, 4}},
+            md::mdarray<T, md::extents<size_t, 3>>{std::array<T, 3>{1, 5, 2}}),
+        md::mdarray<T, md::extents<size_t, 3>>{std::array<T, 3>{1, 3, 2}}));
+
+    static_assert(
+        md::array_equal(md::minimum(md::eye<T, md::extents<size_t, 2, 2>>(),
+                                    md::mdarray<T, md::extents<size_t, 2>>{
+                                        std::array<T, 2>{0.5, 2}}),
+                        md::mdarray<T, md::extents<size_t, 2, 2>>{
+                            std::array<T, 4>{0.5, 0, 0, 1}}));
+}


### PR DESCRIPTION
This pull request introduces new functionality to compute element-wise maximum and minimum values for arrays, along with corresponding unit tests. The primary changes include adding the `maximum` and `minimum` operations to the library and creating test cases to validate their behavior.

### New functionality for array operations:
* Added `maximum` operation in `ctmd/maximum.hpp`, including implementations for scalar and batch processing. The operation computes the element-wise maximum of two arrays.
* Added `minimum` operation in `ctmd/minimum.hpp`, including implementations for scalar and batch processing. The operation computes the element-wise minimum of two arrays.

### Integration into the library:
* Updated `ctmd/ctmd.hpp` to include the new `maximum.hpp` and `minimum.hpp` headers, making the new operations part of the library's public API.

### Unit tests for new functionality:
* Added a Bazel build configuration (`BUILD.bazel`) and a test file (`main.cpp`) for the `maximum` operation under `tests/maximum`. The tests validate the correctness of the element-wise maximum implementation. [[1]](diffhunk://#diff-ff7be450b1dfa175f00427af2eec0a5a0dcb0d90d0ee69fbf0ce34d3290a30a9R1-R17) [[2]](diffhunk://#diff-96c1e0385740c5337f61e752797f88ae5b6982f674620ca3a371d0d42215d1cbR1-R24)
* Added a Bazel build configuration (`BUILD.bazel`) and a test file (`main.cpp`) for the `minimum` operation under `tests/minimum`. The tests validate the correctness of the element-wise minimum implementation. [[1]](diffhunk://#diff-ff7be450b1dfa175f00427af2eec0a5a0dcb0d90d0ee69fbf0ce34d3290a30a9R1-R17) [[2]](diffhunk://#diff-7f7f42b06639f277c061ef00fb9aa31823232af5b9e281b2a6ef64a966c1ba1eR1-R24)