### PR TITLE
develop arange

### DIFF
--- a/ctmd/arange.hpp
+++ b/ctmd/arange.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "core/core.hpp"
+
+namespace ctmd {
+
+template <typename T = void, arithmetic_c start_t, arithmetic_c stop_t,
+          arithmetic_c step_t = double>
+[[nodiscard]] inline constexpr auto
+arange(const start_t &start, const stop_t &stop,
+       const step_t &step = (step_t)1) noexcept {
+    using value_t = std::conditional_t<std::is_void_v<T>,
+                                       std::common_type_t<start_t, stop_t>, T>;
+
+    const size_t num = std::ceil((stop - start) / step);
+    const value_t step_actual =
+        static_cast<value_t>(start + step) - static_cast<value_t>(start);
+
+    auto out = mdarray<value_t, dims<1>>{dims<1>{num}};
+
+    out(0) = start;
+    for (size_t i = 1; i < num; i++) {
+        out(i) = out(i - 1) + step_actual;
+    }
+
+    return out;
+}
+
+template <typename T = void, arithmetic_c stop_t>
+[[nodiscard]] inline constexpr auto arange(const stop_t &stop) noexcept {
+    return arange<T>(0, stop);
+}
+
+} // namespace ctmd

--- a/ctmd/ctmd.hpp
+++ b/ctmd/ctmd.hpp
@@ -7,6 +7,7 @@
 #include "add.hpp"
 #include "all.hpp"
 #include "allclose.hpp"
+#include "arange.hpp"
 #include "array_equal.hpp"
 #include "array_equiv.hpp"
 #include "atan2.hpp"

--- a/tests/arange/BUILD.bazel
+++ b/tests/arange/BUILD.bazel
@@ -1,0 +1,17 @@
+cc_test(
+    name = "main",
+    srcs = [
+        "main.cpp",
+        ],
+    copts = [
+        "-O3",
+        "-funroll-loops",
+        "-fno-rtti",
+        "-Wall",
+        "-march=native",
+    ],
+    deps = [
+        "@gtest//:gtest_main",
+        "//:ctmd",
+    ],
+)

--- a/tests/arange/main.cpp
+++ b/tests/arange/main.cpp
@@ -1,0 +1,34 @@
+#include <gtest/gtest.h>
+
+#include "ctmd/arange.hpp"
+#include "ctmd/array_equal.hpp"
+
+namespace md = ctmd;
+
+TEST(test, 1) {
+    ASSERT_TRUE(md::array_equal(
+        md::arange<int>(0, 5, 0.5),
+        md::mdarray<int, md::extents<size_t, 10>>{
+            std::array<int, 10>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}));
+
+    ASSERT_TRUE(md::array_equal(
+        md::arange<int>(-3, 3, 0.5),
+        md::mdarray<int, md::extents<size_t, 12>>{
+            std::array<int, 12>{-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8}}));
+
+    ASSERT_TRUE(md::array_equal(
+        md::arange(3),
+        md::mdarray<int, md::extents<size_t, 3>>{std::array<int, 3>{0, 1, 2}}));
+
+    ASSERT_TRUE(md::array_equal(md::arange(3.),
+                                md::mdarray<double, md::extents<size_t, 3>>{
+                                    std::array<double, 3>{0, 1, 2}}));
+
+    ASSERT_TRUE(md::array_equal(md::arange(3, 7),
+                                md::mdarray<double, md::extents<size_t, 4>>{
+                                    std::array<double, 4>{3, 4, 5, 6}}));
+
+    ASSERT_TRUE(md::array_equal(md::arange(3, 7, 2),
+                                md::mdarray<double, md::extents<size_t, 2>>{
+                                    std::array<double, 2>{3, 5}}));
+}


### PR DESCRIPTION
This pull request introduces a new `arange` function to the `ctmd` library, which generates evenly spaced values within a specified range. It also includes the necessary integration, testing, and build configuration updates to support this functionality.

### New Feature: `arange` Function

* Added the `arange` function in `ctmd/arange.hpp` to generate evenly spaced values, with overloads for specifying start, stop, and step values. The function uses templates to support various numeric types.

### Integration into `ctmd` Library

* Updated `ctmd/ctmd.hpp` to include the new `arange.hpp` header, making the `arange` function accessible through the main library interface.

### Testing

* Added a new test file, `tests/arange/main.cpp`, with several unit tests to validate the behavior of the `arange` function under different input scenarios. Tests include cases for integer and floating-point ranges, as well as default and custom step values.

### Build Configuration

* Created a Bazel build configuration in `tests/arange/BUILD.bazel` to compile and run the `arange` function tests. The configuration specifies compiler options and dependencies, including Google Test.