### PR TITLE
Update submdspan.hpp

### DIFF
--- a/ctmd/core/submdspan.hpp
+++ b/ctmd/core/submdspan.hpp
@@ -4,70 +4,47 @@
 #include "type.hpp"
 
 namespace ctmd {
+
+template <typename InType, typename... slices_t>
+[[nodiscard]] inline constexpr auto submdspan(InType &&In,
+                                              slices_t &&...slices) noexcept {
+    return std::experimental::submdspan(
+        core::to_mdspan(std::forward<InType>(In)),
+        std::forward<slices_t>(slices)...);
+}
+
 namespace core {
 
-template <size_t lspace, size_t rspace, mdspan_c in_t, typename... slices_t>
+template <size_t lspace, size_t rspace, typename InType, typename... slices_t>
 [[nodiscard]] inline constexpr auto
-submdspan_with_space(const in_t &in, slices_t &&...slices) noexcept {
-    static_assert(in_t::rank() == lspace + sizeof...(slices_t) + rspace,
-                  "The number of slices must match the rank of the input "
-                  "mdspan.");
-
+submdspan_with_space(InType &&In, slices_t &&...slices) noexcept {
     return [&]<size_t... Is, size_t... Js>(std::index_sequence<Is...>,
                                            std::index_sequence<Js...>) {
-        return ctmd::submdspan(in, ((void)Is, ctmd::full_extent)...,
+        return ctmd::submdspan(std::forward<InType>(In),
+                               ((void)Is, ctmd::full_extent)...,
                                std::forward<slices_t>(slices)...,
                                ((void)Js, ctmd::full_extent)...);
     }(std::make_index_sequence<lspace>{}, std::make_index_sequence<rspace>{});
 }
 
-template <size_t lspace, size_t rspace, typename InType, typename... slices_t>
-[[nodiscard]] inline constexpr auto
-submdspan_with_space(InType &&In, slices_t &&...slices) noexcept {
-    const auto in = core::to_mdspan(std::forward<InType>(In));
-
-    return submdspan_with_space<lspace, rspace>(
-        in, std::forward<slices_t>(slices)...);
-}
-
-template <size_t lspace = 0, mdspan_c in_t, typename... slices_t>
-[[nodiscard]] inline constexpr auto
-submdspan_from_left(const in_t &in, slices_t &&...slices) noexcept {
-    static_assert(
-        in_t::rank() >= lspace + sizeof...(slices_t),
-        "The number of slices must not exceed the rank of the input mdspan.");
-
-    constexpr size_t rspace = in_t::rank() - (lspace + sizeof...(slices_t));
-    return submdspan_with_space<lspace, rspace>(
-        in, std::forward<slices_t>(slices)...);
-}
-
 template <size_t lspace = 0, typename InType, typename... slices_t>
 [[nodiscard]] inline constexpr auto
 submdspan_from_left(InType &&In, slices_t &&...slices) noexcept {
-    const auto in = core::to_mdspan(std::forward<InType>(In));
+    constexpr size_t rspace =
+        to_mdspan_t<InType>::rank() - (lspace + sizeof...(slices_t));
 
-    return submdspan_from_left<lspace>(in, std::forward<slices_t>(slices)...);
-}
-
-template <size_t rspace = 0, mdspan_c in_t, typename... slices_t>
-[[nodiscard]] inline constexpr auto
-submdspan_from_right(const in_t &in, slices_t &&...slices) noexcept {
-    static_assert(
-        in_t::rank() >= rspace + sizeof...(slices_t),
-        "The number of slices must not exceed the rank of the input mdspan.");
-
-    constexpr size_t lspace = in_t::rank() - (rspace + sizeof...(slices_t));
     return submdspan_with_space<lspace, rspace>(
-        in, std::forward<slices_t>(slices)...);
+        std::forward<InType>(In), std::forward<slices_t>(slices)...);
 }
 
 template <size_t rspace = 0, typename InType, typename... slices_t>
 [[nodiscard]] inline constexpr auto
 submdspan_from_right(InType &&In, slices_t &&...slices) noexcept {
-    const auto in = core::to_mdspan(std::forward<InType>(In));
+    constexpr size_t lspace =
+        to_mdspan_t<InType>::rank() - (rspace + sizeof...(slices_t));
 
-    return submdspan_from_right<rspace>(in, std::forward<slices_t>(slices)...);
+    return submdspan_with_space<lspace, rspace>(
+        std::forward<InType>(In), std::forward<slices_t>(slices)...);
 }
 
 } // namespace core


### PR DESCRIPTION
This pull request refactors and simplifies the `submdspan` utilities in the `ctmd/core/submdspan.hpp` file. The changes primarily focus on improving type flexibility, reducing code duplication, and enhancing maintainability by consolidating logic and removing redundant functions.

### Refactoring and Consolidation:

* Introduced a new `submdspan` function that wraps `std::experimental::submdspan` and uses `core::to_mdspan` to handle input type conversion, simplifying the interface for creating sub-mdspans.
* Refactored `submdspan_with_space` to directly accept and process the input type (`InType`) without requiring prior conversion to `mdspan`, removing the need for an intermediate overload.

### Code Simplification:

* Removed redundant overloads of `submdspan_with_space`, `submdspan_from_left`, and `submdspan_from_right` that previously handled `mdspan_c` types explicitly, consolidating logic into the remaining templates.
* Simplified `submdspan_from_left` and `submdspan_from_right` by calculating `rspace` and `lspace` directly using the rank of the input type (`to_mdspan_t<InType>::rank()`), reducing code complexity.