### PR TITLE
dtype implemented

### DIFF
--- a/ctmd/absolute.hpp
+++ b/ctmd/absolute.hpp
@@ -32,10 +32,10 @@ inline constexpr void absolute(InType &&In, OutType &&Out,
         core::to_const_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename InType>
+template <typename dtype = void, typename InType>
 [[nodiscard]] inline constexpr auto
 absolute(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::absolute_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/add.hpp
+++ b/ctmd/add.hpp
@@ -56,6 +56,9 @@ inline constexpr void add(In1Type &&In1, In2Type &&In2, OutType &&Out,
 /**
  * @brief Add arguments element-wise.
  *
+ * @tparam dtype (optional) data type of the result. If void, deduced from
+ * inputs.
+ *
  * @param In1 md-like or scalar.
  * @param In2 md-like or scalar.
  * @param mpmode (optional) Parallel execution mode. Default is MPMode::NONE.
@@ -67,10 +70,10 @@ inline constexpr void add(In1Type &&In1, In2Type &&In2, OutType &&Out,
  * @see ctmd::add(In1Type&&, In2Type&&, OutType&&, MPMode) for the in-place
  * version that modifies the output.
  */
-template <typename In1Type, typename In2Type>
+template <typename dtype = void, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 add(In1Type &&In1, In2Type &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::add_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/arange.hpp
+++ b/ctmd/arange.hpp
@@ -4,13 +4,13 @@
 
 namespace ctmd {
 
-template <typename T = void, arithmetic_c start_t, arithmetic_c stop_t,
+template <typename data_t = void, arithmetic_c start_t, arithmetic_c stop_t,
           arithmetic_c step_t = double>
 [[nodiscard]] inline constexpr auto
 arange(const start_t &start, const stop_t &stop,
        const step_t &step = (step_t)1) noexcept {
-    using value_t = std::conditional_t<std::is_void_v<T>,
-                                       std::common_type_t<start_t, stop_t>, T>;
+    using value_t = std::conditional_t<!std::is_void_v<data_t>, data_t,
+                                       core::common_type_t<start_t, stop_t>>;
 
     const size_t num = std::ceil((stop - start) / step);
     const value_t step_actual =
@@ -26,9 +26,9 @@ arange(const start_t &start, const stop_t &stop,
     return out;
 }
 
-template <typename T = void, arithmetic_c stop_t>
+template <typename data_t = void, arithmetic_c stop_t>
 [[nodiscard]] inline constexpr auto arange(const stop_t &stop) noexcept {
-    return arange<T>(0, stop);
+    return arange<data_t>(0, stop);
 }
 
 } // namespace ctmd

--- a/ctmd/atan2.hpp
+++ b/ctmd/atan2.hpp
@@ -31,11 +31,11 @@ inline constexpr void atan2(In1Type &&In1, In2Type &&In2, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename In1Type, typename In2Type>
+template <typename dtype = void, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 atan2(In1Type &&In1, In2Type &&In2,
       const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out<float>(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::atan2_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/clip.hpp
+++ b/ctmd/clip.hpp
@@ -39,11 +39,12 @@ inline constexpr void clip(InType &&In, MinType &&Min, MaxType &&Max,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename InType, typename MinType, typename MaxType>
+template <typename dtype = void, typename InType, typename MinType,
+          typename MaxType>
 [[nodiscard]] inline constexpr auto
 clip(InType &&In, MinType &&Min, MaxType &&Max,
      const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::clip_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/concatenate.hpp
+++ b/ctmd/concatenate.hpp
@@ -114,11 +114,11 @@ concatenate(std::tuple<InsTypes...> &&Ins) noexcept {
     }(std::make_index_sequence<num_ins>{});
 
     // generate out
-    using T = decltype([]<size_t... Is>(std::index_sequence<Is...>) {
+    using dtype = decltype([]<size_t... Is>(std::index_sequence<Is...>) {
         return std::common_type_t<
             core::value_type_t<std::tuple_element_t<Is, ins_t>>...>{};
     }(std::make_index_sequence<num_ins>{}));
-    auto out = ctmd::empty<T>(out_extents);
+    auto out = ctmd::empty<dtype>(out_extents);
 
     // concatenate
     [&ins, &out]<size_t... Is>(std::index_sequence<Is...>) {

--- a/ctmd/copy.hpp
+++ b/ctmd/copy.hpp
@@ -25,10 +25,10 @@ inline constexpr void copy(InType &&In, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename InType>
+template <typename dtype = void, typename InType>
 [[nodiscard]] inline constexpr auto
 copy(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::copy_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/core/broadcast.hpp
+++ b/ctmd/core/broadcast.hpp
@@ -275,27 +275,56 @@ inline constexpr void batch_impl(Func &&func, std::index_sequence<offsets...>,
 
 } // namespace detail
 
-template <typename T, extents_c exts_t>
+template <typename dtype, extents_c exts_t>
 [[nodiscard]] inline constexpr auto create_out(const exts_t &exts) noexcept {
     if constexpr (exts_t::rank() == 0) {
-        return T{};
+        return dtype{};
 
     } else {
-        return ctmd::mdarray<T, exts_t>{exts};
+        return ctmd::mdarray<dtype, exts_t>{exts};
     }
 }
 
-template <typename T = int8_t, size_t... offsets, size_t... uranks,
+namespace detail {
+
+template <typename... Ts> struct filter_nullopt;
+
+template <> struct filter_nullopt<> {
+    using type = std::tuple<>;
+};
+
+template <typename T, typename... Ts> struct filter_nullopt<T, Ts...> {
+  private:
+    using Tail = typename filter_nullopt<Ts...>::type;
+
+  public:
+    using type = std::conditional_t<
+        std::is_same_v<std::remove_cvref_t<T>, std::nullopt_t>, Tail,
+        decltype(std::tuple_cat(std::declval<std::tuple<T>>(),
+                                std::declval<Tail>()))>;
+};
+
+template <typename Tuple> struct tuple_common_type;
+
+template <typename... Ts> struct tuple_common_type<std::tuple<Ts...>> {
+    using type = std::common_type_t<Ts...>;
+};
+
+} // namespace detail
+
+template <typename... Ts>
+using common_type_t = typename detail::tuple_common_type<
+    typename detail::filter_nullopt<Ts...>::type>::type;
+
+template <typename dtype = void, size_t... offsets, size_t... uranks,
           extents_c uout_exts_t, mdspan_c... ins_t>
     requires(sizeof...(offsets) == sizeof...(ins_t) + 1 &&
              sizeof...(uranks) == sizeof...(ins_t))
 [[nodiscard]] inline constexpr auto
 create_out(std::index_sequence<offsets...>, std::index_sequence<uranks...>,
            const uout_exts_t &uout_exts, const ins_t &...ins) noexcept {
-    using value_t = std::common_type_t<
-        T,
-        std::conditional_t<std::is_same_v<value_type_t<ins_t>, std::nullopt_t>,
-                           T, value_type_t<ins_t>>...>;
+    using value_t = std::conditional_t<!std::is_void_v<dtype>, dtype,
+                                       common_type_t<value_type_t<ins_t>...>>;
 
     constexpr auto ofst = std::array{offsets...};
     constexpr auto ur = std::array{uranks...};
@@ -319,20 +348,20 @@ create_out(std::index_sequence<offsets...>, std::index_sequence<uranks...>,
         slice_from_right<uout_exts_t::rank() - uout_offset>(uout_exts)));
 }
 
-template <typename T = int8_t, size_t... uranks, extents_c uout_exts_t,
+template <typename dtype = void, size_t... uranks, extents_c uout_exts_t,
           mdspan_c... ins_t>
     requires(sizeof...(uranks) == sizeof...(ins_t))
 [[nodiscard]] inline constexpr auto create_out(std::index_sequence<uranks...>,
                                                const uout_exts_t &uout_exts,
                                                const ins_t &...ins) noexcept {
     return [&]<size_t... Is>(std::index_sequence<Is...>) {
-        return create_out<T>(std::index_sequence<((void)Is, 0)...>{},
-                             std::index_sequence<uranks...>{}, uout_exts,
-                             ins...);
+        return create_out<dtype>(std::index_sequence<((void)Is, 0)...>{},
+                                 std::index_sequence<uranks...>{}, uout_exts,
+                                 ins...);
     }(std::make_index_sequence<sizeof...(ins_t) + 1>{});
 }
 
-template <typename T = int8_t, size_t... offsets, size_t... uranks,
+template <typename dtype = void, size_t... offsets, size_t... uranks,
           extents_c... uouts_exts_t, mdspan_c... ins_t>
     requires(sizeof...(offsets) == sizeof...(ins_t) + sizeof...(uouts_exts_t) &&
              sizeof...(uranks) == sizeof...(ins_t))
@@ -340,7 +369,8 @@ template <typename T = int8_t, size_t... offsets, size_t... uranks,
 create_out(std::index_sequence<offsets...>, std::index_sequence<uranks...>,
            const std::tuple<uouts_exts_t...> &uouts_exts,
            const ins_t &...ins) noexcept {
-    using value_t = std::common_type_t<T, value_type_t<ins_t>...>;
+    using value_t = std::conditional_t<!std::is_void_v<dtype>, dtype,
+                                       common_type_t<value_type_t<ins_t>...>>;
 
     constexpr auto ofst = std::array{offsets...};
     constexpr auto ur = std::array{uranks...};
@@ -368,7 +398,7 @@ create_out(std::index_sequence<offsets...>, std::index_sequence<uranks...>,
     }(std::make_index_sequence<sizeof...(uouts_exts_t)>{});
 }
 
-template <typename T = int8_t, size_t... uranks, extents_c... uouts_exts_t,
+template <typename dtype = void, size_t... uranks, extents_c... uouts_exts_t,
           mdspan_c... ins_t>
     requires(sizeof...(uranks) == sizeof...(ins_t))
 [[nodiscard]] inline constexpr auto
@@ -376,9 +406,9 @@ create_out(std::index_sequence<uranks...>,
            const std::tuple<uouts_exts_t...> &uouts_exts,
            const ins_t &...ins) noexcept {
     return [&]<size_t... Is>(std::index_sequence<Is...>) {
-        return create_out<T>(std::index_sequence<((void)Is, 0)...>{},
-                             std::index_sequence<uranks...>{}, uouts_exts,
-                             ins...);
+        return create_out<dtype>(std::index_sequence<((void)Is, 0)...>{},
+                                 std::index_sequence<uranks...>{}, uouts_exts,
+                                 ins...);
     }(std::make_index_sequence<sizeof...(ins_t) + sizeof...(uouts_exts_t)>{});
 }
 
@@ -493,7 +523,7 @@ inline constexpr void batch(Func &&func, std::index_sequence<uranks...>,
     }(std::make_index_sequence<sizeof...(ins_t)>{});
 }
 
-template <typename T = int8_t, typename Func, size_t... offsets,
+template <typename dtype = void, typename Func, size_t... offsets,
           size_t... uranks, extents_c uout_exts_t, mdspan_c... ins_t>
     requires(sizeof...(offsets) == sizeof...(ins_t) + 1 &&
              sizeof...(uranks) == sizeof...(ins_t))
@@ -502,8 +532,8 @@ batch_out(Func &&func, std::index_sequence<offsets...>,
           std::index_sequence<uranks...>, const uout_exts_t &uout_exts,
           const MPMode mpmode, const ins_t &...ins) noexcept {
     auto out =
-        create_out<T>(std::index_sequence<offsets...>{},
-                      std::index_sequence<uranks...>{}, uout_exts, ins...);
+        create_out<dtype>(std::index_sequence<offsets...>{},
+                          std::index_sequence<uranks...>{}, uout_exts, ins...);
 
     batch(std::forward<Func>(func), std::index_sequence<offsets...>{},
           std::index_sequence<uranks..., uout_exts_t::rank()>{}, mpmode, ins...,
@@ -512,7 +542,7 @@ batch_out(Func &&func, std::index_sequence<offsets...>,
     return out;
 }
 
-template <typename T = int8_t, typename Func, size_t... uranks,
+template <typename dtype = void, typename Func, size_t... uranks,
           extents_c uout_exts_t, mdspan_c... ins_t>
     requires(sizeof...(uranks) == sizeof...(ins_t))
 [[nodiscard]] inline constexpr auto
@@ -520,13 +550,13 @@ batch_out(Func &&func, std::index_sequence<uranks...>,
           const uout_exts_t &uout_exts, const MPMode mpmode,
           const ins_t &...ins) noexcept {
     return [&]<size_t... Is>(std::index_sequence<Is...>) {
-        return batch_out<T>(
+        return batch_out<dtype>(
             std::forward<Func>(func), std::index_sequence<((void)Is, 0)...>{},
             std::index_sequence<uranks...>{}, uout_exts, mpmode, ins...);
     }(std::make_index_sequence<sizeof...(ins_t) + 1>{});
 }
 
-template <typename T = int8_t, typename Func, size_t... offsets,
+template <typename dtype = void, typename Func, size_t... offsets,
           size_t... uranks, extents_c... uouts_exts_t, mdspan_c... ins_t>
     requires(sizeof...(offsets) == sizeof...(ins_t) + sizeof...(uouts_exts_t) &&
              sizeof...(uranks) == sizeof...(ins_t))
@@ -536,8 +566,8 @@ batch_out(Func &&func, std::index_sequence<offsets...>,
           const std::tuple<uouts_exts_t...> &uouts_exts, const MPMode mpmode,
           const ins_t &...ins) noexcept {
     auto out =
-        create_out<T>(std::index_sequence<offsets...>{},
-                      std::index_sequence<uranks...>{}, uouts_exts, ins...);
+        create_out<dtype>(std::index_sequence<offsets...>{},
+                          std::index_sequence<uranks...>{}, uouts_exts, ins...);
 
     [&]<size_t... Is>(std::index_sequence<Is...>) {
         batch(std::forward<Func>(func), std::index_sequence<offsets...>{},
@@ -550,7 +580,7 @@ batch_out(Func &&func, std::index_sequence<offsets...>,
     return out;
 }
 
-template <typename T = int8_t, typename Func, size_t... uranks,
+template <typename dtype = void, typename Func, size_t... uranks,
           extents_c... uouts_exts_t, mdspan_c... ins_t>
     requires(sizeof...(uranks) == sizeof...(ins_t))
 [[nodiscard]] inline constexpr auto
@@ -558,7 +588,7 @@ batch_out(Func &&func, std::index_sequence<uranks...>,
           const std::tuple<uouts_exts_t...> &uouts_exts, const MPMode mpmode,
           const ins_t &...ins) noexcept {
     return [&]<size_t... Is>(std::index_sequence<Is...>) {
-        return batch_out<T>(
+        return batch_out<dtype>(
             std::forward<Func>(func), std::index_sequence<((void)Is, 0)...>{},
             std::index_sequence<uranks...>{}, uouts_exts, mpmode, ins...);
     }(std::make_index_sequence<sizeof...(ins_t) + sizeof...(uouts_exts_t)>{});

--- a/ctmd/cos.hpp
+++ b/ctmd/cos.hpp
@@ -26,10 +26,10 @@ inline constexpr void cos(InType &&In, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename InType>
+template <typename dtype = void, typename InType>
 [[nodiscard]] inline constexpr auto
 cos(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out<float>(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::cos_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/deg2rad.hpp
+++ b/ctmd/deg2rad.hpp
@@ -14,13 +14,13 @@ inline constexpr void deg2rad(InType &&In, OutType &&Out,
                    mpmode);
 }
 
-template <typename InType>
+template <typename dtype = void, typename InType>
 [[nodiscard]] inline constexpr auto
 deg2rad(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
     using TI = decltype(core::to_mdspan(std::forward<InType>(In)))::value_type;
     constexpr TI D2R = static_cast<TI>(M_PI / 180.);
 
-    return ctmd::multiply(std::forward<InType>(In), D2R, mpmode);
+    return ctmd::multiply<dtype>(std::forward<InType>(In), D2R, mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/divide.hpp
+++ b/ctmd/divide.hpp
@@ -27,11 +27,11 @@ inline constexpr void divide(In1Type &&In1, In2Type &&In2, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename In1Type, typename In2Type>
+template <typename dtype = void, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 divide(In1Type &&In1, In2Type &&In2,
        const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::divide_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/empty.hpp
+++ b/ctmd/empty.hpp
@@ -4,10 +4,10 @@
 
 namespace ctmd {
 
-template <typename T, extents_c exts_t = extents<size_t>>
+template <typename dtype, extents_c exts_t = extents<size_t>>
 [[nodiscard]] inline constexpr auto
 empty(const exts_t &exts = exts_t{}) noexcept {
-    return core::create_out<T>(exts);
+    return core::create_out<dtype>(exts);
 }
 
 } // namespace ctmd

--- a/ctmd/empty_like.hpp
+++ b/ctmd/empty_like.hpp
@@ -7,14 +7,14 @@ namespace ctmd {
 template <typename InType>
 [[nodiscard]] inline constexpr auto empty_like(InType &&In) noexcept {
     const auto in = core::to_const_mdspan(std::forward<InType>(In));
-    using T = typename decltype(in)::value_type;
-    return ctmd::empty<T>(in.extents());
+    using dtype = typename decltype(in)::value_type;
+    return ctmd::empty<dtype>(in.extents());
 }
 
-template <typename T, typename InType>
+template <typename dtype, typename InType>
 [[nodiscard]] inline constexpr auto empty_like(InType &&In) noexcept {
     const auto in = core::to_const_mdspan(std::forward<InType>(In));
-    return ctmd::empty<T>(in.extents());
+    return ctmd::empty<dtype>(in.extents());
 }
 
 } // namespace ctmd

--- a/ctmd/equal.hpp
+++ b/ctmd/equal.hpp
@@ -27,11 +27,11 @@ inline constexpr void equal(In1Type &&In1, In2Type &&In2, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename In1Type, typename In2Type>
+template <typename dtype = int8_t, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 equal(In1Type &&In1, In2Type &&In2,
       const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::equal_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/eye.hpp
+++ b/ctmd/eye.hpp
@@ -28,11 +28,11 @@ inline constexpr void eye(InType &&In,
         core::to_mdspan(std::forward<InType>(In)));
 }
 
-template <typename T, extents_c extents_t>
+template <typename dtype, extents_c extents_t>
 [[nodiscard]] inline constexpr auto
 eye(const extents_t &extents = extents_t{},
     const MPMode mpmode = MPMode::NONE) noexcept {
-    auto out = ctmd::empty<T>(extents);
+    auto out = ctmd::empty<dtype>(extents);
     ctmd::eye(out, mpmode);
     return out;
 }

--- a/ctmd/full.hpp
+++ b/ctmd/full.hpp
@@ -5,11 +5,11 @@
 
 namespace ctmd {
 
-template <typename T, extents_c extents_t>
+template <typename dtype, extents_c extents_t>
 [[nodiscard]] inline constexpr auto
-full(const T &val, const extents_t &extents = extents_t{},
+full(const dtype &val, const extents_t &extents = extents_t{},
      const MPMode mpmode = MPMode::NONE) noexcept {
-    auto out = ctmd::empty<T>(extents);
+    auto out = ctmd::empty<dtype>(extents);
     ctmd::fill(out, val, mpmode);
     return out;
 }

--- a/ctmd/full_like.hpp
+++ b/ctmd/full_like.hpp
@@ -14,11 +14,11 @@ full_like(InType &&In, const val_t &val,
     return out;
 }
 
-template <typename T, typename InType, typename val_t>
+template <typename dtype, typename InType, typename val_t>
 [[nodiscard]] inline constexpr auto
 full_like(InType &&In, const val_t &val,
           const MPMode mpmode = MPMode::NONE) noexcept {
-    auto out = ctmd::empty_like<T>(std::forward<InType>(In));
+    auto out = ctmd::empty_like<dtype>(std::forward<InType>(In));
     ctmd::fill(out, val, mpmode);
     return out;
 }

--- a/ctmd/greater.hpp
+++ b/ctmd/greater.hpp
@@ -27,11 +27,11 @@ inline constexpr void greater(In1Type &&In1, In2Type &&In2, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename In1Type, typename In2Type>
+template <typename dtype = int8_t, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 greater(In1Type &&In1, In2Type &&In2,
         const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::greater_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/greater_equal.hpp
+++ b/ctmd/greater_equal.hpp
@@ -28,11 +28,11 @@ greater_equal(In1Type &&In1, In2Type &&In2, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename In1Type, typename In2Type>
+template <typename dtype = int8_t, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 greater_equal(In1Type &&In1, In2Type &&In2,
               const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::greater_equal_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/isclose.hpp
+++ b/ctmd/isclose.hpp
@@ -10,10 +10,10 @@ template <mdspan_c in1_t, mdspan_c in2_t, mdspan_c out_t>
 inline constexpr void isclose_impl(const in1_t &in1, const in2_t &in2,
                                    const out_t &out, const double &rtol,
                                    const double &atol) noexcept {
-    using T = typename in2_t::value_type;
+    using dtype = typename in2_t::value_type;
     out() = ctmd::absolute(in1() - in2()) <=
-            (static_cast<const T>(atol) +
-             static_cast<const T>(rtol) * ctmd::absolute(in2()));
+            (static_cast<const dtype>(atol) +
+             static_cast<const dtype>(rtol) * ctmd::absolute(in2()));
 }
 
 } // namespace detail
@@ -35,12 +35,12 @@ inline constexpr void isclose(In1Type &&In1, In2Type &&In2, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename In1Type, typename In2Type>
+template <typename dtype = int8_t, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 isclose(In1Type &&In1, In2Type &&In2, const double &rtol = 1e-05,
         const double &atol = 1e-08,
         const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [&](auto &&...elems) {
             detail::isclose_impl(std::forward<decltype(elems)>(elems)..., rtol,
                                  atol);

--- a/ctmd/less.hpp
+++ b/ctmd/less.hpp
@@ -27,11 +27,11 @@ inline constexpr void less(In1Type &&In1, In2Type &&In2, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename In1Type, typename In2Type>
+template <typename dtype = int8_t, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 less(In1Type &&In1, In2Type &&In2,
      const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::less_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/less_equal.hpp
+++ b/ctmd/less_equal.hpp
@@ -27,11 +27,11 @@ inline constexpr void less_equal(In1Type &&In1, In2Type &&In2, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename In1Type, typename In2Type>
+template <typename dtype = int8_t, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 less_equal(In1Type &&In1, In2Type &&In2,
            const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::less_equal_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/linalg/inv.hpp
+++ b/ctmd/linalg/inv.hpp
@@ -83,12 +83,12 @@ inline constexpr void inv(InType &&In, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename InType>
+template <typename dtype = void, typename InType>
 [[nodiscard]] inline constexpr auto
 inv(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
     const auto in = core::to_const_mdspan(std::forward<InType>(In));
 
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::inv_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/linalg/matmul.hpp
+++ b/ctmd/linalg/matmul.hpp
@@ -89,7 +89,7 @@ inline constexpr void matmul(In1Type &&In1, In2Type &&In2, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename In1Type, typename In2Type>
+template <typename dtype = void, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 matmul(In1Type &&In1, In2Type &&In2,
        const MPMode mpmode = MPMode::NONE) noexcept {
@@ -105,7 +105,7 @@ matmul(In1Type &&In1, In2Type &&In2,
                 decltype(uin2_exts)::static_extent(1)>{uin1_exts.extent(0),
                                                        uin2_exts.extent(1)};
 
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::matmul_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/linalg/matvec.hpp
+++ b/ctmd/linalg/matvec.hpp
@@ -86,7 +86,7 @@ inline constexpr void matvec(In1Type &&In1, In2Type &&In2, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename In1Type, typename In2Type>
+template <typename dtype = void, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 matvec(In1Type &&In1, In2Type &&In2,
        const MPMode mpmode = MPMode::NONE) noexcept {
@@ -100,7 +100,7 @@ matvec(In1Type &&In1, In2Type &&In2,
                                    typename decltype(uin2_exts)::index_type>,
                 decltype(uin1_exts)::static_extent(0)>{uin1_exts.extent(0)};
 
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::matvec_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/linalg/norm.hpp
+++ b/ctmd/linalg/norm.hpp
@@ -46,7 +46,7 @@ inline constexpr void norm(InType &&In, OutType &&Out,
         std::index_sequence<1, 0>{}, mpmode, in, out);
 }
 
-template <typename InType>
+template <typename dtype = void, typename InType>
 [[nodiscard]] inline constexpr auto
 norm(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
     const auto in = core::to_const_mdspan(std::forward<InType>(In));
@@ -56,7 +56,7 @@ norm(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
                           mpmode);
     }
 
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::norm_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/linalg/vecmat.hpp
+++ b/ctmd/linalg/vecmat.hpp
@@ -86,7 +86,7 @@ inline constexpr void vecmat(In1Type &&In1, In2Type &&In2, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename In1Type, typename In2Type>
+template <typename dtype = void, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 vecmat(In1Type &&In1, In2Type &&In2,
        const MPMode mpmode = MPMode::NONE) noexcept {
@@ -100,7 +100,7 @@ vecmat(In1Type &&In1, In2Type &&In2,
                                    typename decltype(uin2_exts)::index_type>,
                 decltype(uin2_exts)::static_extent(1)>{uin2_exts.extent(1)};
 
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::vecmat_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/linspace.hpp
+++ b/ctmd/linspace.hpp
@@ -76,7 +76,7 @@ inline constexpr void linspace(start_in_t &&start_in, stop_in_t &&stop_in,
 }
 
 template <int64_t Axis = 0, extents_c exts_t = extents<uint8_t, 50>,
-          typename start_in_t, typename stop_in_t>
+          typename dtype = void, typename start_in_t, typename stop_in_t>
     requires(exts_t::rank() == 1)
 [[nodiscard]] inline constexpr auto
 linspace(start_in_t &&start_in, stop_in_t &&stop_in,
@@ -87,8 +87,10 @@ linspace(start_in_t &&start_in, stop_in_t &&stop_in,
     using start_t = decltype(start);
     using stop_t = decltype(stop);
 
-    using value_t = std::common_type_t<typename start_t::value_type,
-                                       typename stop_t::value_type>;
+    using value_t =
+        std::conditional_t<!std::is_void_v<dtype>, dtype,
+                           core::common_type_t<typename start_t::value_type,
+                                               typename stop_t::value_type>>;
 
     constexpr size_t out_rank = start_t::rank() + 1;
     constexpr size_t axis = static_cast<size_t>(

--- a/ctmd/matmul.hpp
+++ b/ctmd/matmul.hpp
@@ -11,11 +11,11 @@ inline constexpr void matmul(Elems &&...elems) noexcept {
     ctmd::linalg::matmul(std::forward<Elems>(elems)...);
 }
 
-template <typename... Elems>
+template <typename dtype = void, typename... Elems>
     requires(!std::is_void_v<
              decltype(ctmd::linalg::matmul(std::declval<Elems>()...))>)
 [[nodiscard]] inline constexpr auto matmul(Elems &&...elems) noexcept {
-    return ctmd::linalg::matmul(std::forward<Elems>(elems)...);
+    return ctmd::linalg::matmul<dtype>(std::forward<Elems>(elems)...);
 }
 
 } // namespace ctmd

--- a/ctmd/matvec.hpp
+++ b/ctmd/matvec.hpp
@@ -11,11 +11,11 @@ inline constexpr void matvec(Elems &&...elems) noexcept {
     ctmd::linalg::matvec(std::forward<Elems>(elems)...);
 }
 
-template <typename... Elems>
+template <typename dtype = void, typename... Elems>
     requires(!std::is_void_v<
              decltype(ctmd::linalg::matvec(std::declval<Elems>()...))>)
 [[nodiscard]] inline constexpr auto matvec(Elems &&...elems) noexcept {
-    return ctmd::linalg::matvec(std::forward<Elems>(elems)...);
+    return ctmd::linalg::matvec<dtype>(std::forward<Elems>(elems)...);
 }
 
 } // namespace ctmd

--- a/ctmd/maximum.hpp
+++ b/ctmd/maximum.hpp
@@ -28,11 +28,11 @@ inline constexpr void maximum(In1Type &&In1, In2Type &&In2, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename In1Type, typename In2Type>
+template <typename dtype = void, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 maximum(In1Type &&In1, In2Type &&In2,
         const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::maximum_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/minimum.hpp
+++ b/ctmd/minimum.hpp
@@ -28,11 +28,11 @@ inline constexpr void minimum(In1Type &&In1, In2Type &&In2, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename In1Type, typename In2Type>
+template <typename dtype = void, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 minimum(In1Type &&In1, In2Type &&In2,
         const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::minimum_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/multiply.hpp
+++ b/ctmd/multiply.hpp
@@ -27,11 +27,11 @@ inline constexpr void multiply(In1Type &&In1, In2Type &&In2, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename In1Type, typename In2Type>
+template <typename dtype = void, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 multiply(In1Type &&In1, In2Type &&In2,
          const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::multiply_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/negative.hpp
+++ b/ctmd/negative.hpp
@@ -25,10 +25,10 @@ inline constexpr void negative(InType &&In, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename InType>
+template <typename dtype = void, typename InType>
 [[nodiscard]] inline constexpr auto
 negative(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::negative_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/not_equal.hpp
+++ b/ctmd/not_equal.hpp
@@ -27,11 +27,11 @@ inline constexpr void not_equal(In1Type &&In1, In2Type &&In2, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename In1Type, typename In2Type>
+template <typename dtype = int8_t, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 not_equal(In1Type &&In1, In2Type &&In2,
           const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::not_equal_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/ones.hpp
+++ b/ctmd/ones.hpp
@@ -4,11 +4,11 @@
 
 namespace ctmd {
 
-template <typename T, extents_c exts_t = extents<size_t>>
+template <typename dtype, extents_c exts_t = extents<size_t>>
 [[nodiscard]] inline constexpr auto
 zeros(const exts_t &exts = exts_t{},
       const MPMode mpmode = MPMode::NONE) noexcept {
-    return ctmd::full<T>(0, exts, mpmode);
+    return ctmd::full<dtype>(0, exts, mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/ones_like.hpp
+++ b/ctmd/ones_like.hpp
@@ -10,10 +10,10 @@ ones_like(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
     return ctmd::full_like(std::forward<InType>(In), 1, mpmode);
 }
 
-template <typename T, typename InType>
+template <typename dtype, typename InType>
 [[nodiscard]] inline constexpr auto
 ones_like(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    return ctmd::full_like<T>(std::forward<InType>(In), 1, mpmode);
+    return ctmd::full_like<dtype>(std::forward<InType>(In), 1, mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/rad2deg.hpp
+++ b/ctmd/rad2deg.hpp
@@ -14,13 +14,13 @@ inline constexpr void rad2deg(InType &&In, OutType &&Out,
                    mpmode);
 }
 
-template <typename InType>
+template <typename dtype = void, typename InType>
 [[nodiscard]] inline constexpr auto
 rad2deg(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
     using TI = decltype(core::to_mdspan(std::forward<InType>(In)))::value_type;
     constexpr TI R2D = static_cast<TI>(180. / M_PI);
 
-    return ctmd::multiply(std::forward<InType>(In), R2D, mpmode);
+    return ctmd::multiply<dtype>(std::forward<InType>(In), R2D, mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/sin.hpp
+++ b/ctmd/sin.hpp
@@ -26,10 +26,10 @@ inline constexpr void sin(InType &&In, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename InType>
+template <typename dtype = void, typename InType>
 [[nodiscard]] inline constexpr auto
 sin(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out<float>(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::sin_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/sqrt.hpp
+++ b/ctmd/sqrt.hpp
@@ -7,12 +7,13 @@ namespace detail {
 
 #ifndef REAL_GCC
 
-template <floating_point_c T>
-[[nodiscard]] inline constexpr T sqrt_newton_raphson(const T &x, const T &curr,
-                                                     const T &prev) noexcept {
+template <floating_point_c dtype>
+[[nodiscard]] inline constexpr dtype
+sqrt_newton_raphson(const dtype &x, const dtype &curr,
+                    const dtype &prev) noexcept {
     return (curr == prev)
                ? curr
-               : sqrt_newton_raphson(x, (curr + x / curr) / (T)2, curr);
+               : sqrt_newton_raphson(x, (curr + x / curr) / (dtype)2, curr);
 }
 
 #endif
@@ -27,19 +28,20 @@ inline constexpr void sqrt_impl(const in_t &in, const out_t &out) noexcept {
     // NOTE: std::abs is not constexpr in clang 16.
 
     if constexpr (floating_point_c<typename in_t::value_type>) {
-        using T = typename in_t::value_type;
+        using dtype = typename in_t::value_type;
 
-        out() = (in() >= 0 && in() < std::numeric_limits<T>::infinity())
-                    ? sqrt_newton_raphson(in(), in(), (T)0)
-                    : std::numeric_limits<T>::quiet_NaN();
+        out() = (in() >= 0 && in() < std::numeric_limits<dtype>::infinity())
+                    ? sqrt_newton_raphson(in(), in(), (dtype)0)
+                    : std::numeric_limits<dtype>::quiet_NaN();
 
     } else {
-        using T = float;
+        using dtype = float;
 
-        out() = (in() >= 0 && in() < std::numeric_limits<T>::infinity())
-                    ? sqrt_newton_raphson(static_cast<const T>(in()),
-                                          static_cast<const T>(in()), (T)0)
-                    : std::numeric_limits<T>::quiet_NaN();
+        out() =
+            (in() >= 0 && in() < std::numeric_limits<dtype>::infinity())
+                ? sqrt_newton_raphson(static_cast<const dtype>(in()),
+                                      static_cast<const dtype>(in()), (dtype)0)
+                : std::numeric_limits<dtype>::quiet_NaN();
     }
 
 #endif
@@ -59,10 +61,10 @@ inline constexpr void sqrt(InType &&In, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename InType>
+template <typename dtype = void, typename InType>
 [[nodiscard]] inline constexpr auto
 sqrt(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::sqrt_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/subtract.hpp
+++ b/ctmd/subtract.hpp
@@ -27,11 +27,11 @@ inline constexpr void subtract(In1Type &&In1, In2Type &&In2, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename In1Type, typename In2Type>
+template <typename dtype = void, typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr auto
 subtract(In1Type &&In1, In2Type &&In2,
          const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::subtract_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/sum.hpp
+++ b/ctmd/sum.hpp
@@ -38,7 +38,7 @@ inline constexpr void sum(InType &&In, OutType &&Out,
         std::index_sequence<rin_rank, rin_rank - 1>{}, mpmode, in, out);
 }
 
-template <int64_t Axis, typename InType>
+template <int64_t Axis, typename dtype = void, typename InType>
 [[nodiscard]] inline constexpr auto
 sum(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
     const auto in = core::to_const_mdspan(std::forward<InType>(In));
@@ -49,7 +49,7 @@ sum(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
         static_cast<size_t>(
             ((Axis % static_cast<int64_t>(in_rank)) + (in_rank)) % in_rank);
 
-    return core::batch_out(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::sum_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/tan.hpp
+++ b/ctmd/tan.hpp
@@ -26,10 +26,10 @@ inline constexpr void tan(InType &&In, OutType &&Out,
         core::to_mdspan(std::forward<OutType>(Out)));
 }
 
-template <typename InType>
+template <typename dtype = void, typename InType>
 [[nodiscard]] inline constexpr auto
 tan(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    return core::batch_out<float>(
+    return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::tan_impl(std::forward<decltype(elems)>(elems)...);
         },

--- a/ctmd/vecmat.hpp
+++ b/ctmd/vecmat.hpp
@@ -11,11 +11,11 @@ inline constexpr void vecmat(Elems &&...elems) noexcept {
     ctmd::linalg::vecmat(std::forward<Elems>(elems)...);
 }
 
-template <typename... Elems>
+template <typename dtype = void, typename... Elems>
     requires(!std::is_void_v<
              decltype(ctmd::linalg::vecmat(std::declval<Elems>()...))>)
 [[nodiscard]] inline constexpr auto vecmat(Elems &&...elems) noexcept {
-    return ctmd::linalg::vecmat(std::forward<Elems>(elems)...);
+    return ctmd::linalg::vecmat<dtype>(std::forward<Elems>(elems)...);
 }
 
 } // namespace ctmd

--- a/ctmd/zeros.hpp
+++ b/ctmd/zeros.hpp
@@ -4,11 +4,11 @@
 
 namespace ctmd {
 
-template <typename T, extents_c exts_t = extents<size_t>>
+template <typename dtype, extents_c exts_t = extents<size_t>>
 [[nodiscard]] inline constexpr auto
 ones(const exts_t &exts = exts_t{},
      const MPMode mpmode = MPMode::NONE) noexcept {
-    return ctmd::full<T>(1, exts, mpmode);
+    return ctmd::full<dtype>(1, exts, mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/zeros_like.hpp
+++ b/ctmd/zeros_like.hpp
@@ -10,10 +10,10 @@ zeros_like(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
     return ctmd::full_like(std::forward<InType>(In), 0, mpmode);
 }
 
-template <typename T, typename InType>
+template <typename dtype, typename InType>
 [[nodiscard]] inline constexpr auto
 zeros_like(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    return ctmd::full_like<T>(std::forward<InType>(In), 0, mpmode);
+    return ctmd::full_like<dtype>(std::forward<InType>(In), 0, mpmode);
 }
 
 } // namespace ctmd

--- a/tests/add/main.cpp
+++ b/tests/add/main.cpp
@@ -2,6 +2,7 @@
 
 #include "ctmd/add.hpp"
 #include "ctmd/allclose.hpp"
+#include "ctmd/to_string.hpp" // TODO: remove
 
 namespace md = ctmd;
 


### PR DESCRIPTION
This pull request introduces a consistent approach to specifying the data type (`dtype`) for various mathematical and array operations in the `ctmd` library. The changes improve flexibility by allowing the user to explicitly define the output data type or rely on type deduction when `dtype` is set to `void`. Additionally, several utility functions have been refactored to enhance type handling and maintainability.

### Generalization of `dtype` Parameter Across Functions

* **Mathematical Operations**: Updated functions like `absolute`, `add`, `atan2`, `clip`, `cos`, `deg2rad`, `divide`, and `equal` to include an optional `dtype` parameter, allowing explicit specification of the output data type or type deduction when `dtype` is `void`. [[1]](diffhunk://#diff-aec17a41b7f74077877bb026f91dc326538e676f26f2fa1d8e60bcaf164f6a12L35-R38) [[2]](diffhunk://#diff-c9994732d1e6002884a7013c301398a806166350d007f6a41f26487c54e48f20L70-R76) [[3]](diffhunk://#diff-92a1648264edfaada2ef3fc9e753431662713f50d60dd4eebd760f33234cf49dL34-R38) [[4]](diffhunk://#diff-5756e30dae44a8d7449b13438e9947cdf16b2b4495bfa5bcf96824a43ad0e9b2L42-R47) [[5]](diffhunk://#diff-17cb1195c19519259a657dda7fffdccf4f8f77a93b7f57a3ea7596d79196f30bL29-R32) [[6]](diffhunk://#diff-7564f72f8a9443c1cd1308c2fa40605660e81a06e847bbbac99ad231d70ef20eL17-R23) [[7]](diffhunk://#diff-9e21edfeacd67bf2681c5c915acf54197f1b6eba1f93c09da8f30d2c7708ab98L30-R34) [[8]](diffhunk://#diff-6da32ce63be03c48085ff58b9d27eb5d346d49ddc2eab91ab9d2b41ddb254b67L30-R34)

* **Array Creation and Manipulation**: Updated functions such as `empty`, `empty_like`, `eye`, and `arange` to use `dtype` instead of hardcoded or deduced types, enhancing flexibility. [[1]](diffhunk://#diff-d91cc5bf67ab4b94fb7deb19e0321c957b4e98f6fb04683b412f9fa1953fd857L7-R10) [[2]](diffhunk://#diff-6d2609e74aaa1f5c4bb7aa17f25eda7d444cee39bd0dd3dff74f618addaf83b6L10-R17) [[3]](diffhunk://#diff-7f69fd4676ef55401a9540f24d339113bf04c3fed80c98e9e3cdd4b7cb15ad4dL31-R35) [[4]](diffhunk://#diff-0b0767f6c34da0ac525f42627480e30cd49fd20d5bba2a5e93b1d1b88ca7cfe9L7-R13)

### Refactoring for Type Handling

* **Broadcast Utilities**: Refactored `create_out` and `batch_out` functions to use `dtype` and introduced helper utilities like `filter_nullopt` and `tuple_common_type` for better type management. This ensures consistent handling of mixed types and `std::nullopt`. [[1]](diffhunk://#diff-dc6cef58ae7cb2fd5532008043b6ed5719dbebc87d1d5ebb82e04f5b30c34b08L278-R327) [[2]](diffhunk://#diff-dc6cef58ae7cb2fd5532008043b6ed5719dbebc87d1d5ebb82e04f5b30c34b08L322-R373) [[3]](diffhunk://#diff-dc6cef58ae7cb2fd5532008043b6ed5719dbebc87d1d5ebb82e04f5b30c34b08L371-R409) [[4]](diffhunk://#diff-dc6cef58ae7cb2fd5532008043b6ed5719dbebc87d1d5ebb82e04f5b30c34b08L496-R526) [[5]](diffhunk://#diff-dc6cef58ae7cb2fd5532008043b6ed5719dbebc87d1d5ebb82e04f5b30c34b08L539-R569)

* **Concatenation**: Changed the type alias from `T` to `dtype` in the `concatenate` function to align with the new type specification approach.

These updates enhance the library's usability by providing more control over type specification, improving consistency, and simplifying type-related logic.