### PR TITLE
perfect forwarding with auto&&

### DIFF
--- a/benchmarks/isclose/none/source.hpp
+++ b/benchmarks/isclose/none/source.hpp
@@ -18,7 +18,7 @@ template <typename T> inline void test(benchmark::State &state) noexcept {
     auto out = md::mdarray<T, md::dims<1>>{md::dims<1>{set_num}};
 
     for (auto _ : state) {
-        md::isclose(in1, in2, out);
+        md::isclose_to(in1, in2, out);
     }
 
     state.SetComplexityN(state.range(0));

--- a/ctmd/absolute.hpp
+++ b/ctmd/absolute.hpp
@@ -20,27 +20,26 @@ inline constexpr void absolute_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename InType, typename OutType>
-inline constexpr void absolute(InType &&In, OutType &&Out,
+inline constexpr void absolute(auto &&In, auto &&Out,
                                const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::absolute_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)),
-        core::to_const_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        core::to_const_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename InType>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-absolute(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+absolute(auto &&In, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::absolute_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)));
 }
 
 } // namespace ctmd

--- a/ctmd/add.hpp
+++ b/ctmd/add.hpp
@@ -37,20 +37,19 @@ inline constexpr void add_impl(const in1_t &in1, const in2_t &in2,
  *
  * @note Equivalent to In1 + In2 = Out in terms of array broadcasting.
  *
- * @see ctmd::add(In1Type&&, In2Type&&, MPMode) for the in-place version that
- * returns the result.
+ * @see ctmd::add(auto&&, auto&&, MPMode) for the in-place version that returns
+ * the result.
  */
-template <typename In1Type, typename In2Type, typename OutType>
-inline constexpr void add(In1Type &&In1, In2Type &&In2, OutType &&Out,
+inline constexpr void add(auto &&In1, auto &&In2, auto &&Out,
                           const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::add_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
 /**
@@ -67,19 +66,19 @@ inline constexpr void add(In1Type &&In1, In2Type &&In2, OutType &&Out,
  *
  * @note Equivalent to In1 + In2 = Out in terms of array broadcasting.
  *
- * @see ctmd::add(In1Type&&, In2Type&&, OutType&&, MPMode) for the in-place
- * version that modifies the output.
+ * @see ctmd::add(auto&&, auto&&, auto&&, MPMode) for the in-place version that
+ * modifies the output.
  */
-template <typename dtype = void, typename In1Type, typename In2Type>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-add(In1Type &&In1, In2Type &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
+add(auto &&In1, auto &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::add_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }
 
 } // namespace ctmd

--- a/ctmd/all.hpp
+++ b/ctmd/all.hpp
@@ -4,9 +4,8 @@
 
 namespace ctmd {
 
-template <typename InType>
-[[nodiscard]] inline constexpr bool all(InType &&In) noexcept {
-    const auto in = core::to_const_mdspan(std::forward<InType>(In));
+[[nodiscard]] inline constexpr bool all(auto &&In) noexcept {
+    const auto in = core::to_const_mdspan(std::forward<decltype(In)>(In));
     using in_t = decltype(in);
 
     if constexpr (in_t::rank() == 0) {

--- a/ctmd/allclose.hpp
+++ b/ctmd/allclose.hpp
@@ -5,13 +5,12 @@
 
 namespace ctmd {
 
-template <typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr bool
-allclose(In1Type &&In1, In2Type &&In2, const double &rtol = 1e-05,
+allclose(auto &&In1, auto &&In2, const double &rtol = 1e-05,
          const double &atol = 1e-08,
          const MPMode mpmode = MPMode::NONE) noexcept {
-    return ctmd::all(ctmd::isclose(std::forward<In1Type>(In1),
-                                   std::forward<In2Type>(In2), rtol, atol,
+    return ctmd::all(ctmd::isclose(std::forward<decltype(In1)>(In1),
+                                   std::forward<decltype(In2)>(In2), rtol, atol,
                                    mpmode));
 }
 

--- a/ctmd/array_equal.hpp
+++ b/ctmd/array_equal.hpp
@@ -4,11 +4,10 @@
 
 namespace ctmd {
 
-template <typename In1Type, typename In2Type>
-[[nodiscard]] inline constexpr bool array_equal(In1Type &&In1,
-                                                In2Type &&In2) noexcept {
-    const auto in1 = core::to_const_mdspan(std::forward<In1Type>(In1));
-    const auto in2 = core::to_const_mdspan(std::forward<In2Type>(In2));
+[[nodiscard]] inline constexpr bool array_equal(auto &&In1,
+                                                auto &&In2) noexcept {
+    const auto in1 = core::to_const_mdspan(std::forward<decltype(In1)>(In1));
+    const auto in2 = core::to_const_mdspan(std::forward<decltype(In2)>(In2));
     using in1_t = decltype(in1);
     using in2_t = decltype(in2);
 

--- a/ctmd/array_equiv.hpp
+++ b/ctmd/array_equiv.hpp
@@ -5,12 +5,11 @@
 
 namespace ctmd {
 
-template <typename In1Type, typename In2Type>
 [[nodiscard]] inline constexpr bool
-array_equiv(In1Type &&In1, In2Type &&In2,
+array_equiv(auto &&In1, auto &&In2,
             const MPMode mpmode = MPMode::NONE) noexcept {
-    return ctmd::all(ctmd::equal(std::forward<In1Type>(In1),
-                                 std::forward<In2Type>(In2), mpmode));
+    return ctmd::all(ctmd::equal(std::forward<decltype(In1)>(In1),
+                                 std::forward<decltype(In2)>(In2), mpmode));
 }
 
 } // namespace ctmd

--- a/ctmd/atan2.hpp
+++ b/ctmd/atan2.hpp
@@ -18,30 +18,28 @@ inline constexpr void atan2_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename In1Type, typename In2Type, typename OutType>
-inline constexpr void atan2(In1Type &&In1, In2Type &&In2, OutType &&Out,
+inline constexpr void atan2(auto &&In1, auto &&In2, auto &&Out,
                             const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::atan2_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename In1Type, typename In2Type>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-atan2(In1Type &&In1, In2Type &&In2,
-      const MPMode mpmode = MPMode::NONE) noexcept {
+atan2(auto &&In1, auto &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::atan2_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }
 
 } // namespace ctmd

--- a/ctmd/clip.hpp
+++ b/ctmd/clip.hpp
@@ -24,34 +24,31 @@ inline constexpr void clip_impl(const in_t &in, const min_t &min,
 
 } // namespace detail
 
-template <typename InType, typename MinType, typename MaxType, typename OutType>
-inline constexpr void clip(InType &&In, MinType &&Min, MaxType &&Max,
-                           OutType &&Out,
+inline constexpr void clip(auto &&In, auto &&Min, auto &&Max, auto &&Out,
                            const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::clip_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)),
-        core::to_const_mdspan(std::forward<MinType>(Min)),
-        core::to_const_mdspan(std::forward<MaxType>(Max)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        core::to_const_mdspan(std::forward<decltype(Min)>(Min)),
+        core::to_const_mdspan(std::forward<decltype(Max)>(Max)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename InType, typename MinType,
-          typename MaxType>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-clip(InType &&In, MinType &&Min, MaxType &&Max,
+clip(auto &&In, auto &&Min, auto &&Max,
      const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::clip_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)),
-        core::to_const_mdspan(std::forward<MinType>(Min)),
-        core::to_const_mdspan(std::forward<MaxType>(Max)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        core::to_const_mdspan(std::forward<decltype(Min)>(Min)),
+        core::to_const_mdspan(std::forward<decltype(Max)>(Max)));
 }
 
 } // namespace ctmd

--- a/ctmd/copy.hpp
+++ b/ctmd/copy.hpp
@@ -13,27 +13,26 @@ inline constexpr void copy_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename InType, typename OutType>
-inline constexpr void copy(InType &&In, OutType &&Out,
+inline constexpr void copy(auto &&In, auto &&Out,
                            const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::copy_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename InType>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-copy(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+copy(auto &&In, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::copy_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)));
 }
 
 } // namespace ctmd

--- a/ctmd/core/convert.hpp
+++ b/ctmd/core/convert.hpp
@@ -5,12 +5,11 @@
 namespace ctmd {
 namespace core {
 
-template <typename InType>
-[[nodiscard]] inline constexpr auto to_mdspan(InType &&In) noexcept {
-    using BaseType = std::remove_reference_t<InType>;
+[[nodiscard]] inline constexpr auto to_mdspan(auto &&In) noexcept {
+    using BaseType = std::remove_reference_t<decltype(In)>;
 
     if constexpr (mdspan_c<BaseType>) {
-        return std::forward<InType>(In);
+        return std::forward<decltype(In)>(In);
 
     } else if constexpr (requires { In.to_mdspan(); }) {
         return In.to_mdspan();
@@ -35,9 +34,8 @@ template <mdspan_c in_t>
     }
 }
 
-template <typename InType>
-[[nodiscard]] inline constexpr auto to_const_mdspan(InType &&In) noexcept {
-    return to_const(to_mdspan(std::forward<InType>(In)));
+[[nodiscard]] inline constexpr auto to_const_mdspan(auto &&In) noexcept {
+    return to_const(to_mdspan(std::forward<decltype(In)>(In)));
 }
 
 template <mdspan_c in_t>
@@ -51,10 +49,10 @@ template <mdspan_c in_t>
     return in.is_unique() && in.is_exhaustive() && in.is_strided();
 }
 
-template <typename InType, extents_c extents_t>
+template <extents_c extents_t>
 [[nodiscard]] inline constexpr auto
-reshape(InType &&In, const extents_t &new_extents = extents_t{}) noexcept {
-    const auto in = to_mdspan(std::forward<InType>(In));
+reshape(auto &&In, const extents_t &new_extents = extents_t{}) noexcept {
+    const auto in = to_mdspan(std::forward<decltype(In)>(In));
     using in_t = decltype(in);
 
     assert(is_reshapable(in));

--- a/ctmd/core/submdspan.hpp
+++ b/ctmd/core/submdspan.hpp
@@ -5,46 +5,46 @@
 
 namespace ctmd {
 
-template <typename InType, typename... slices_t>
-[[nodiscard]] inline constexpr auto submdspan(InType &&In,
+template <typename... slices_t>
+[[nodiscard]] inline constexpr auto submdspan(auto &&In,
                                               slices_t &&...slices) noexcept {
     return std::experimental::submdspan(
-        core::to_mdspan(std::forward<InType>(In)),
+        core::to_mdspan(std::forward<decltype(In)>(In)),
         std::forward<slices_t>(slices)...);
 }
 
 namespace core {
 
-template <size_t lspace, size_t rspace, typename InType, typename... slices_t>
+template <size_t lspace, size_t rspace, typename... slices_t>
 [[nodiscard]] inline constexpr auto
-submdspan_with_space(InType &&In, slices_t &&...slices) noexcept {
+submdspan_with_space(auto &&In, slices_t &&...slices) noexcept {
     return [&]<size_t... Is, size_t... Js>(std::index_sequence<Is...>,
                                            std::index_sequence<Js...>) {
-        return ctmd::submdspan(std::forward<InType>(In),
+        return ctmd::submdspan(std::forward<decltype(In)>(In),
                                ((void)Is, ctmd::full_extent)...,
                                std::forward<slices_t>(slices)...,
                                ((void)Js, ctmd::full_extent)...);
     }(std::make_index_sequence<lspace>{}, std::make_index_sequence<rspace>{});
 }
 
-template <size_t lspace = 0, typename InType, typename... slices_t>
+template <size_t lspace = 0, typename... slices_t>
 [[nodiscard]] inline constexpr auto
-submdspan_from_left(InType &&In, slices_t &&...slices) noexcept {
+submdspan_from_left(auto &&In, slices_t &&...slices) noexcept {
     constexpr size_t rspace =
-        to_mdspan_t<InType>::rank() - (lspace + sizeof...(slices_t));
+        to_mdspan_t<decltype(In)>::rank() - (lspace + sizeof...(slices_t));
 
     return submdspan_with_space<lspace, rspace>(
-        std::forward<InType>(In), std::forward<slices_t>(slices)...);
+        std::forward<decltype(In)>(In), std::forward<slices_t>(slices)...);
 }
 
-template <size_t rspace = 0, typename InType, typename... slices_t>
+template <size_t rspace = 0, typename... slices_t>
 [[nodiscard]] inline constexpr auto
-submdspan_from_right(InType &&In, slices_t &&...slices) noexcept {
+submdspan_from_right(auto &&In, slices_t &&...slices) noexcept {
     constexpr size_t lspace =
-        to_mdspan_t<InType>::rank() - (rspace + sizeof...(slices_t));
+        to_mdspan_t<decltype(In)>::rank() - (rspace + sizeof...(slices_t));
 
     return submdspan_with_space<lspace, rspace>(
-        std::forward<InType>(In), std::forward<slices_t>(slices)...);
+        std::forward<decltype(In)>(In), std::forward<slices_t>(slices)...);
 }
 
 } // namespace core

--- a/ctmd/cos.hpp
+++ b/ctmd/cos.hpp
@@ -14,27 +14,26 @@ inline constexpr void cos_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename InType, typename OutType>
-inline constexpr void cos(InType &&In, OutType &&Out,
+inline constexpr void cos(auto &&In, auto &&Out,
                           const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::cos_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename InType>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-cos(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+cos(auto &&In, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::cos_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)));
 }
 
 } // namespace ctmd

--- a/ctmd/deg2rad.hpp
+++ b/ctmd/deg2rad.hpp
@@ -4,23 +4,24 @@
 
 namespace ctmd {
 
-template <typename InType, typename OutType>
-inline constexpr void deg2rad(InType &&In, OutType &&Out,
+inline constexpr void deg2rad(auto &&In, auto &&Out,
                               const MPMode mpmode = MPMode::NONE) noexcept {
-    using TI = decltype(core::to_mdspan(std::forward<InType>(In)))::value_type;
+    using TI =
+        decltype(core::to_mdspan(std::forward<decltype(In)>(In)))::value_type;
     constexpr TI D2R = static_cast<TI>(M_PI / 180.);
 
-    ctmd::multiply(std::forward<InType>(In), D2R, std::forward<OutType>(Out),
-                   mpmode);
+    ctmd::multiply(std::forward<decltype(In)>(In), D2R,
+                   std::forward<decltype(Out)>(Out), mpmode);
 }
 
-template <typename dtype = void, typename InType>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-deg2rad(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    using TI = decltype(core::to_mdspan(std::forward<InType>(In)))::value_type;
+deg2rad(auto &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    using TI =
+        decltype(core::to_mdspan(std::forward<decltype(In)>(In)))::value_type;
     constexpr TI D2R = static_cast<TI>(M_PI / 180.);
 
-    return ctmd::multiply<dtype>(std::forward<InType>(In), D2R, mpmode);
+    return ctmd::multiply<dtype>(std::forward<decltype(In)>(In), D2R, mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/divide.hpp
+++ b/ctmd/divide.hpp
@@ -14,30 +14,28 @@ inline constexpr void divide_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename In1Type, typename In2Type, typename OutType>
-inline constexpr void divide(In1Type &&In1, In2Type &&In2, OutType &&Out,
+inline constexpr void divide(auto &&In1, auto &&In2, auto &&Out,
                              const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::divide_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename In1Type, typename In2Type>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-divide(In1Type &&In1, In2Type &&In2,
-       const MPMode mpmode = MPMode::NONE) noexcept {
+divide(auto &&In1, auto &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::divide_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }
 
 } // namespace ctmd

--- a/ctmd/empty_like.hpp
+++ b/ctmd/empty_like.hpp
@@ -4,16 +4,15 @@
 
 namespace ctmd {
 
-template <typename InType>
-[[nodiscard]] inline constexpr auto empty_like(InType &&In) noexcept {
-    const auto in = core::to_const_mdspan(std::forward<InType>(In));
+[[nodiscard]] inline constexpr auto empty_like(auto &&In) noexcept {
+    const auto in = core::to_const_mdspan(std::forward<decltype(In)>(In));
     using dtype = typename decltype(in)::value_type;
     return ctmd::empty<dtype>(in.extents());
 }
 
-template <typename dtype, typename InType>
-[[nodiscard]] inline constexpr auto empty_like(InType &&In) noexcept {
-    const auto in = core::to_const_mdspan(std::forward<InType>(In));
+template <typename dtype>
+[[nodiscard]] inline constexpr auto empty_like(auto &&In) noexcept {
+    const auto in = core::to_const_mdspan(std::forward<decltype(In)>(In));
     return ctmd::empty<dtype>(in.extents());
 }
 

--- a/ctmd/equal.hpp
+++ b/ctmd/equal.hpp
@@ -14,30 +14,28 @@ inline constexpr void equal_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename In1Type, typename In2Type, typename OutType>
-inline constexpr void equal(In1Type &&In1, In2Type &&In2, OutType &&Out,
+inline constexpr void equal(auto &&In1, auto &&In2, auto &&Out,
                             const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::equal_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = int8_t, typename In1Type, typename In2Type>
+template <typename dtype = int8_t>
 [[nodiscard]] inline constexpr auto
-equal(In1Type &&In1, In2Type &&In2,
-      const MPMode mpmode = MPMode::NONE) noexcept {
+equal(auto &&In1, auto &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::equal_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }
 
 } // namespace ctmd

--- a/ctmd/expand_dims.hpp
+++ b/ctmd/expand_dims.hpp
@@ -4,9 +4,9 @@
 
 namespace ctmd {
 
-template <int64_t Axis, typename InType>
-[[nodiscard]] inline constexpr auto expand_dims(InType &&In) noexcept {
-    const auto in = core::to_const_mdspan(std::forward<InType>(In));
+template <int64_t Axis>
+[[nodiscard]] inline constexpr auto expand_dims(auto &&In) noexcept {
+    const auto in = core::to_const_mdspan(std::forward<decltype(In)>(In));
     using in_t = decltype(in);
 
     constexpr size_t rank = in_t::rank();
@@ -32,7 +32,7 @@ template <int64_t Axis, typename InType>
                                : (Is == axis ? 1 : in.extent(Is - 1)))...};
             }(std::make_index_sequence<rank + 1>{});
 
-        return ctmd::reshape(std::forward<InType>(In), new_extents);
+        return ctmd::reshape(std::forward<decltype(In)>(In), new_extents);
     }
 }
 

--- a/ctmd/eye.hpp
+++ b/ctmd/eye.hpp
@@ -17,15 +17,14 @@ inline constexpr void eye_impl(const in_t &in) noexcept {
 
 } // namespace detail
 
-template <typename InType>
-inline constexpr void eye(InType &&In,
+inline constexpr void eye(auto &&In,
                           const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::eye_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<2>{}, mpmode,
-        core::to_mdspan(std::forward<InType>(In)));
+        core::to_mdspan(std::forward<decltype(In)>(In)));
 }
 
 template <typename dtype, extents_c extents_t>

--- a/ctmd/fill.hpp
+++ b/ctmd/fill.hpp
@@ -5,23 +5,22 @@
 namespace ctmd {
 namespace detail {
 
-template <mdspan_c in_t, typename val_t>
+template <mdspan_c in_t>
     requires(in_t::rank() == 0)
-inline constexpr void fill_impl(const in_t &in, const val_t &val) noexcept {
+inline constexpr void fill_impl(const in_t &in, const auto &val) noexcept {
     in() = val;
 }
 
 } // namespace detail
 
-template <typename InType, typename val_t>
-inline constexpr void fill(InType &&In, const val_t &val,
+inline constexpr void fill(auto &&In, const auto &val,
                            const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [&](auto &&...elems) {
             detail::fill_impl(std::forward<decltype(elems)>(elems)..., val);
         },
         std::index_sequence<0>{}, mpmode,
-        core::to_mdspan(std::forward<InType>(In)));
+        core::to_mdspan(std::forward<decltype(In)>(In)));
 }
 
 } // namespace ctmd

--- a/ctmd/full_like.hpp
+++ b/ctmd/full_like.hpp
@@ -5,20 +5,19 @@
 
 namespace ctmd {
 
-template <typename InType, typename val_t>
 [[nodiscard]] inline constexpr auto
-full_like(InType &&In, const val_t &val,
+full_like(auto &&In, const auto &val,
           const MPMode mpmode = MPMode::NONE) noexcept {
-    auto out = ctmd::empty_like(std::forward<InType>(In));
+    auto out = ctmd::empty_like(std::forward<decltype(In)>(In));
     ctmd::fill(out, val, mpmode);
     return out;
 }
 
-template <typename dtype, typename InType, typename val_t>
+template <typename dtype>
 [[nodiscard]] inline constexpr auto
-full_like(InType &&In, const val_t &val,
+full_like(auto &&In, const auto &val,
           const MPMode mpmode = MPMode::NONE) noexcept {
-    auto out = ctmd::empty_like<dtype>(std::forward<InType>(In));
+    auto out = ctmd::empty_like<dtype>(std::forward<decltype(In)>(In));
     ctmd::fill(out, val, mpmode);
     return out;
 }

--- a/ctmd/greater.hpp
+++ b/ctmd/greater.hpp
@@ -14,30 +14,28 @@ inline constexpr void greater_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename In1Type, typename In2Type, typename OutType>
-inline constexpr void greater(In1Type &&In1, In2Type &&In2, OutType &&Out,
+inline constexpr void greater(auto &&In1, auto &&In2, auto &&Out,
                               const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::greater_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = int8_t, typename In1Type, typename In2Type>
+template <typename dtype = int8_t>
 [[nodiscard]] inline constexpr auto
-greater(In1Type &&In1, In2Type &&In2,
-        const MPMode mpmode = MPMode::NONE) noexcept {
+greater(auto &&In1, auto &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::greater_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }
 
 } // namespace ctmd

--- a/ctmd/greater_equal.hpp
+++ b/ctmd/greater_equal.hpp
@@ -14,31 +14,30 @@ inline constexpr void greater_equal_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename In1Type, typename In2Type, typename OutType>
 inline constexpr void
-greater_equal(In1Type &&In1, In2Type &&In2, OutType &&Out,
+greater_equal(auto &&In1, auto &&In2, auto &&Out,
               const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::greater_equal_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = int8_t, typename In1Type, typename In2Type>
+template <typename dtype = int8_t>
 [[nodiscard]] inline constexpr auto
-greater_equal(In1Type &&In1, In2Type &&In2,
+greater_equal(auto &&In1, auto &&In2,
               const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::greater_equal_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }
 
 } // namespace ctmd

--- a/ctmd/isclose.hpp
+++ b/ctmd/isclose.hpp
@@ -18,26 +18,24 @@ inline constexpr void isclose_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename In1Type, typename In2Type, typename OutType>
-    requires(!arithmetic_c<OutType>)
-inline constexpr void isclose(In1Type &&In1, In2Type &&In2, OutType &&Out,
-                              const double &rtol = 1e-05,
-                              const double &atol = 1e-08,
-                              const MPMode mpmode = MPMode::NONE) noexcept {
+inline constexpr void isclose_to(auto &&In1, auto &&In2, auto &&Out,
+                                 const double &rtol = 1e-05,
+                                 const double &atol = 1e-08,
+                                 const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [&](auto &&...elems) {
             detail::isclose_impl(std::forward<decltype(elems)>(elems)..., rtol,
                                  atol);
         },
         std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = int8_t, typename In1Type, typename In2Type>
+template <typename dtype = int8_t>
 [[nodiscard]] inline constexpr auto
-isclose(In1Type &&In1, In2Type &&In2, const double &rtol = 1e-05,
+isclose(auto &&In1, auto &&In2, const double &rtol = 1e-05,
         const double &atol = 1e-08,
         const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
@@ -46,8 +44,8 @@ isclose(In1Type &&In1, In2Type &&In2, const double &rtol = 1e-05,
                                  atol);
         },
         std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }
 
 } // namespace ctmd

--- a/ctmd/less.hpp
+++ b/ctmd/less.hpp
@@ -14,30 +14,28 @@ inline constexpr void less_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename In1Type, typename In2Type, typename OutType>
-inline constexpr void less(In1Type &&In1, In2Type &&In2, OutType &&Out,
+inline constexpr void less(auto &&In1, auto &&In2, auto &&Out,
                            const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::less_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = int8_t, typename In1Type, typename In2Type>
+template <typename dtype = int8_t>
 [[nodiscard]] inline constexpr auto
-less(In1Type &&In1, In2Type &&In2,
-     const MPMode mpmode = MPMode::NONE) noexcept {
+less(auto &&In1, auto &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::less_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }
 
 } // namespace ctmd

--- a/ctmd/less_equal.hpp
+++ b/ctmd/less_equal.hpp
@@ -14,30 +14,29 @@ inline constexpr void less_equal_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename In1Type, typename In2Type, typename OutType>
-inline constexpr void less_equal(In1Type &&In1, In2Type &&In2, OutType &&Out,
+inline constexpr void less_equal(auto &&In1, auto &&In2, auto &&Out,
                                  const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::less_equal_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = int8_t, typename In1Type, typename In2Type>
+template <typename dtype = int8_t>
 [[nodiscard]] inline constexpr auto
-less_equal(In1Type &&In1, In2Type &&In2,
+less_equal(auto &&In1, auto &&In2,
            const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::less_equal_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }
 
 } // namespace ctmd

--- a/ctmd/linalg/inv.hpp
+++ b/ctmd/linalg/inv.hpp
@@ -71,22 +71,21 @@ inline constexpr void inv_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename InType, typename OutType>
-inline constexpr void inv(InType &&In, OutType &&Out,
+inline constexpr void inv(auto &&In, auto &&Out,
                           const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::inv_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<2, 2>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename InType>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-inv(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto in = core::to_const_mdspan(std::forward<InType>(In));
+inv(auto &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in = core::to_const_mdspan(std::forward<decltype(In)>(In));
 
     return core::batch_out<dtype>(
         [](auto &&...elems) {

--- a/ctmd/linalg/matmul.hpp
+++ b/ctmd/linalg/matmul.hpp
@@ -80,25 +80,23 @@ inline constexpr void matmul_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename In1Type, typename In2Type, typename OutType>
-inline constexpr void matmul(In1Type &&In1, In2Type &&In2, OutType &&Out,
+inline constexpr void matmul(auto &&In1, auto &&In2, auto &&Out,
                              const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::matmul_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<2, 2, 2>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename In1Type, typename In2Type>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-matmul(In1Type &&In1, In2Type &&In2,
-       const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto in1 = core::to_const_mdspan(std::forward<In1Type>(In1));
-    const auto in2 = core::to_const_mdspan(std::forward<In2Type>(In2));
+matmul(auto &&In1, auto &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in1 = core::to_const_mdspan(std::forward<decltype(In1)>(In1));
+    const auto in2 = core::to_const_mdspan(std::forward<decltype(In2)>(In2));
 
     const auto uin1_exts = core::slice_from_right<2>(in1.extents());
     const auto uin2_exts = core::slice_from_right<2>(in2.extents());

--- a/ctmd/linalg/matvec.hpp
+++ b/ctmd/linalg/matvec.hpp
@@ -77,25 +77,23 @@ inline constexpr void matvec_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename In1Type, typename In2Type, typename OutType>
-inline constexpr void matvec(In1Type &&In1, In2Type &&In2, OutType &&Out,
+inline constexpr void matvec(auto &&In1, auto &&In2, auto &&Out,
                              const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::matvec_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<2, 1, 1>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename In1Type, typename In2Type>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-matvec(In1Type &&In1, In2Type &&In2,
-       const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto in1 = core::to_const_mdspan(std::forward<In1Type>(In1));
-    const auto in2 = core::to_const_mdspan(std::forward<In2Type>(In2));
+matvec(auto &&In1, auto &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in1 = core::to_const_mdspan(std::forward<decltype(In1)>(In1));
+    const auto in2 = core::to_const_mdspan(std::forward<decltype(In2)>(In2));
 
     const auto uin1_exts = core::slice_from_right<2>(in1.extents());
     const auto uin2_exts = core::slice_from_right<1>(in2.extents());

--- a/ctmd/linalg/norm.hpp
+++ b/ctmd/linalg/norm.hpp
@@ -27,11 +27,10 @@ inline constexpr void norm_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename InType, typename OutType>
-inline constexpr void norm(InType &&In, OutType &&Out,
+inline constexpr void norm(auto &&In, auto &&Out,
                            const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto in = core::to_const_mdspan(std::forward<InType>(In));
-    const auto out = core::to_mdspan(std::forward<OutType>(Out));
+    const auto in = core::to_const_mdspan(std::forward<decltype(In)>(In));
+    const auto out = core::to_mdspan(std::forward<decltype(Out)>(Out));
 
     if (mpmode == MPMode::SIMD) [[unlikely]] {
         ctmd::sum<-1>(ctmd::multiply(in, in, mpmode), out, mpmode);
@@ -46,10 +45,10 @@ inline constexpr void norm(InType &&In, OutType &&Out,
         std::index_sequence<1, 0>{}, mpmode, in, out);
 }
 
-template <typename dtype = void, typename InType>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-norm(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto in = core::to_const_mdspan(std::forward<InType>(In));
+norm(auto &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in = core::to_const_mdspan(std::forward<decltype(In)>(In));
     auto out = core::create_out<dtype>(std::index_sequence<1>{},
                                        ctmd::extents<uint8_t>{}, in);
 

--- a/ctmd/linalg/vecmat.hpp
+++ b/ctmd/linalg/vecmat.hpp
@@ -77,25 +77,23 @@ inline constexpr void vecmat_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename In1Type, typename In2Type, typename OutType>
-inline constexpr void vecmat(In1Type &&In1, In2Type &&In2, OutType &&Out,
+inline constexpr void vecmat(auto &&In1, auto &&In2, auto &&Out,
                              const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::vecmat_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<1, 2, 1>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename In1Type, typename In2Type>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-vecmat(In1Type &&In1, In2Type &&In2,
-       const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto in1 = core::to_const_mdspan(std::forward<In1Type>(In1));
-    const auto in2 = core::to_mdspan(std::forward<In2Type>(In2));
+vecmat(auto &&In1, auto &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in1 = core::to_const_mdspan(std::forward<decltype(In1)>(In1));
+    const auto in2 = core::to_mdspan(std::forward<decltype(In2)>(In2));
 
     const auto uin1_exts = core::slice_from_right<1>(in1.extents());
     const auto uin2_exts = core::slice_from_right<2>(in2.extents());

--- a/ctmd/linspace.hpp
+++ b/ctmd/linspace.hpp
@@ -35,16 +35,15 @@ inline constexpr void linspace_impl(const start_t &start, const stop_t &stop,
 
 } // namespace detail
 
-template <int64_t Axis = 0, typename start_in_t, typename stop_in_t,
-          typename out_in_t>
-    requires(!extents_c<out_in_t>)
-inline constexpr void linspace(start_in_t &&start_in, stop_in_t &&stop_in,
-                               out_in_t &&out_in,
-                               const bool endpoint = true) noexcept {
+template <int64_t Axis = 0>
+inline constexpr void linspace_to(auto &&start_in, auto &&stop_in,
+                                  auto &&out_in,
+                                  const bool endpoint = true) noexcept {
     const auto start =
-        core::to_const_mdspan(std::forward<start_in_t>(start_in));
-    const auto stop = core::to_const_mdspan(std::forward<stop_in_t>(stop_in));
-    const auto out = core::to_mdspan(std::forward<out_in_t>(out_in));
+        core::to_const_mdspan(std::forward<decltype(start_in)>(start_in));
+    const auto stop =
+        core::to_const_mdspan(std::forward<decltype(stop_in)>(stop_in));
+    const auto out = core::to_mdspan(std::forward<decltype(out_in)>(out_in));
     using start_t = decltype(start);
     using stop_t = decltype(stop);
     using out_t = decltype(out);
@@ -67,7 +66,7 @@ inline constexpr void linspace(start_in_t &&start_in, stop_in_t &&stop_in,
         assert(start.extent(0) == out.extent(lspace));
 
         for (typename out_t::index_type i = 0; i < out.extent(lspace); i++) {
-            linspace<axis - (lspace == 0 ? 1 : 0)>(
+            linspace_to<axis - (lspace == 0 ? 1 : 0)>(
                 core::submdspan_from_left(start, i),
                 core::submdspan_from_left(stop, i),
                 core::submdspan_from_left<lspace>(out, i), endpoint);
@@ -76,14 +75,15 @@ inline constexpr void linspace(start_in_t &&start_in, stop_in_t &&stop_in,
 }
 
 template <int64_t Axis = 0, extents_c exts_t = extents<uint8_t, 50>,
-          typename dtype = void, typename start_in_t, typename stop_in_t>
+          typename dtype = void>
     requires(exts_t::rank() == 1)
 [[nodiscard]] inline constexpr auto
-linspace(start_in_t &&start_in, stop_in_t &&stop_in,
-         const exts_t &exts = exts_t{}, const bool endpoint = true) noexcept {
+linspace(auto &&start_in, auto &&stop_in, const exts_t &exts = exts_t{},
+         const bool endpoint = true) noexcept {
     const auto start =
-        core::to_const_mdspan(std::forward<start_in_t>(start_in));
-    const auto stop = core::to_const_mdspan(std::forward<stop_in_t>(stop_in));
+        core::to_const_mdspan(std::forward<decltype(start_in)>(start_in));
+    const auto stop =
+        core::to_const_mdspan(std::forward<decltype(stop_in)>(stop_in));
     using start_t = decltype(start);
     using stop_t = decltype(stop);
 
@@ -101,7 +101,7 @@ linspace(start_in_t &&start_in, stop_in_t &&stop_in,
         core::slice_from_left<axis>(bexts), exts,
         core::slice_from_right<decltype(bexts)::rank() - axis>(bexts)));
 
-    linspace<Axis>(start, stop, out, endpoint);
+    linspace_to<Axis>(start, stop, out, endpoint);
 
     return out;
 }

--- a/ctmd/maximum.hpp
+++ b/ctmd/maximum.hpp
@@ -15,30 +15,28 @@ inline constexpr void maximum_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename In1Type, typename In2Type, typename OutType>
-inline constexpr void maximum(In1Type &&In1, In2Type &&In2, OutType &&Out,
+inline constexpr void maximum(auto &&In1, auto &&In2, auto &&Out,
                               const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::maximum_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename In1Type, typename In2Type>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-maximum(In1Type &&In1, In2Type &&In2,
-        const MPMode mpmode = MPMode::NONE) noexcept {
+maximum(auto &&In1, auto &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::maximum_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }
 
 } // namespace ctmd

--- a/ctmd/minimum.hpp
+++ b/ctmd/minimum.hpp
@@ -15,30 +15,28 @@ inline constexpr void minimum_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename In1Type, typename In2Type, typename OutType>
-inline constexpr void minimum(In1Type &&In1, In2Type &&In2, OutType &&Out,
+inline constexpr void minimum(auto &&In1, auto &&In2, auto &&Out,
                               const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::minimum_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename In1Type, typename In2Type>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-minimum(In1Type &&In1, In2Type &&In2,
-        const MPMode mpmode = MPMode::NONE) noexcept {
+minimum(auto &&In1, auto &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::minimum_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }
 
 } // namespace ctmd

--- a/ctmd/multiply.hpp
+++ b/ctmd/multiply.hpp
@@ -14,30 +14,28 @@ inline constexpr void multiply_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename In1Type, typename In2Type, typename OutType>
-inline constexpr void multiply(In1Type &&In1, In2Type &&In2, OutType &&Out,
+inline constexpr void multiply(auto &&In1, auto &&In2, auto &&Out,
                                const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::multiply_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename In1Type, typename In2Type>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-multiply(In1Type &&In1, In2Type &&In2,
-         const MPMode mpmode = MPMode::NONE) noexcept {
+multiply(auto &&In1, auto &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::multiply_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }
 
 } // namespace ctmd

--- a/ctmd/negative.hpp
+++ b/ctmd/negative.hpp
@@ -13,27 +13,26 @@ inline constexpr void negative_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename InType, typename OutType>
-inline constexpr void negative(InType &&In, OutType &&Out,
+inline constexpr void negative(auto &&In, auto &&Out,
                                const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::negative_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename InType>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-negative(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+negative(auto &&In, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::negative_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)));
 }
 
 } // namespace ctmd

--- a/ctmd/not_equal.hpp
+++ b/ctmd/not_equal.hpp
@@ -14,30 +14,28 @@ inline constexpr void not_equal_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename In1Type, typename In2Type, typename OutType>
-inline constexpr void not_equal(In1Type &&In1, In2Type &&In2, OutType &&Out,
+inline constexpr void not_equal(auto &&In1, auto &&In2, auto &&Out,
                                 const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::not_equal_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = int8_t, typename In1Type, typename In2Type>
+template <typename dtype = int8_t>
 [[nodiscard]] inline constexpr auto
-not_equal(In1Type &&In1, In2Type &&In2,
-          const MPMode mpmode = MPMode::NONE) noexcept {
+not_equal(auto &&In1, auto &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::not_equal_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }
 
 } // namespace ctmd

--- a/ctmd/ones_like.hpp
+++ b/ctmd/ones_like.hpp
@@ -4,16 +4,15 @@
 
 namespace ctmd {
 
-template <typename InType>
 [[nodiscard]] inline constexpr auto
-ones_like(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    return ctmd::full_like(std::forward<InType>(In), 1, mpmode);
+ones_like(auto &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    return ctmd::full_like(std::forward<decltype(In)>(In), 1, mpmode);
 }
 
-template <typename dtype, typename InType>
+template <typename dtype>
 [[nodiscard]] inline constexpr auto
-ones_like(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    return ctmd::full_like<dtype>(std::forward<InType>(In), 1, mpmode);
+ones_like(auto &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    return ctmd::full_like<dtype>(std::forward<decltype(In)>(In), 1, mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/rad2deg.hpp
+++ b/ctmd/rad2deg.hpp
@@ -4,23 +4,24 @@
 
 namespace ctmd {
 
-template <typename InType, typename OutType>
-inline constexpr void rad2deg(InType &&In, OutType &&Out,
+inline constexpr void rad2deg(auto &&In, auto &&Out,
                               const MPMode mpmode = MPMode::NONE) noexcept {
-    using TI = decltype(core::to_mdspan(std::forward<InType>(In)))::value_type;
+    using TI =
+        decltype(core::to_mdspan(std::forward<decltype(In)>(In)))::value_type;
     constexpr TI R2D = static_cast<TI>(180. / M_PI);
 
-    ctmd::multiply(std::forward<InType>(In), R2D, std::forward<OutType>(Out),
-                   mpmode);
+    ctmd::multiply(std::forward<decltype(In)>(In), R2D,
+                   std::forward<decltype(Out)>(Out), mpmode);
 }
 
-template <typename dtype = void, typename InType>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-rad2deg(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    using TI = decltype(core::to_mdspan(std::forward<InType>(In)))::value_type;
+rad2deg(auto &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    using TI =
+        decltype(core::to_mdspan(std::forward<decltype(In)>(In)))::value_type;
     constexpr TI R2D = static_cast<TI>(180. / M_PI);
 
-    return ctmd::multiply<dtype>(std::forward<InType>(In), R2D, mpmode);
+    return ctmd::multiply<dtype>(std::forward<decltype(In)>(In), R2D, mpmode);
 }
 
 } // namespace ctmd

--- a/ctmd/random/rand.hpp
+++ b/ctmd/random/rand.hpp
@@ -67,10 +67,9 @@ inline void rand_impl(const in_t &in) noexcept {
 
 } // namespace detail
 
-template <typename InType>
-inline constexpr void rand(InType &&In,
+inline constexpr void rand(auto &&In,
                            const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto in = core::to_mdspan(std::forward<InType>(In));
+    const auto in = core::to_mdspan(std::forward<decltype(In)>(In));
     using in_t = decltype(in);
 
     if constexpr (in_t::rank_dynamic() == 0) {

--- a/ctmd/random/uniform.hpp
+++ b/ctmd/random/uniform.hpp
@@ -7,11 +7,10 @@
 namespace ctmd {
 namespace random {
 
-template <typename InType>
-inline constexpr void uniform(InType &&In, const double &low = 0,
+inline constexpr void uniform(auto &&In, const double &low = 0,
                               const double &high = 1,
                               const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto in = core::to_mdspan(std::forward<InType>(In));
+    const auto in = core::to_mdspan(std::forward<decltype(In)>(In));
 
     using T = typename decltype(in)::value_type;
 

--- a/ctmd/reshape.hpp
+++ b/ctmd/reshape.hpp
@@ -4,10 +4,10 @@
 
 namespace ctmd {
 
-template <typename InType, extents_c extents_t>
+template <extents_c extents_t>
 [[nodiscard]] inline constexpr auto
-reshape(InType &&In, const extents_t &new_extents = extents_t{}) noexcept {
-    return core::reshape(core::to_mdspan(std::forward<InType>(In)),
+reshape(auto &&In, const extents_t &new_extents = extents_t{}) noexcept {
+    return core::reshape(core::to_mdspan(std::forward<decltype(In)>(In)),
                          new_extents);
 }
 

--- a/ctmd/sin.hpp
+++ b/ctmd/sin.hpp
@@ -14,27 +14,26 @@ inline constexpr void sin_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename InType, typename OutType>
-inline constexpr void sin(InType &&In, OutType &&Out,
+inline constexpr void sin(auto &&In, auto &&Out,
                           const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::sin_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename InType>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-sin(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+sin(auto &&In, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::sin_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)));
 }
 
 } // namespace ctmd

--- a/ctmd/sqrt.hpp
+++ b/ctmd/sqrt.hpp
@@ -49,27 +49,26 @@ inline constexpr void sqrt_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename InType, typename OutType>
-inline constexpr void sqrt(InType &&In, OutType &&Out,
+inline constexpr void sqrt(auto &&In, auto &&Out,
                            const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::sqrt_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename InType>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-sqrt(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+sqrt(auto &&In, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::sqrt_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)));
 }
 
 } // namespace ctmd

--- a/ctmd/subtract.hpp
+++ b/ctmd/subtract.hpp
@@ -14,30 +14,28 @@ inline constexpr void subtract_impl(const in1_t &in1, const in2_t &in2,
 
 } // namespace detail
 
-template <typename In1Type, typename In2Type, typename OutType>
-inline constexpr void subtract(In1Type &&In1, In2Type &&In2, OutType &&Out,
+inline constexpr void subtract(auto &&In1, auto &&In2, auto &&Out,
                                const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::subtract_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename In1Type, typename In2Type>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-subtract(In1Type &&In1, In2Type &&In2,
-         const MPMode mpmode = MPMode::NONE) noexcept {
+subtract(auto &&In1, auto &&In2, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::subtract_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<In1Type>(In1)),
-        core::to_const_mdspan(std::forward<In2Type>(In2)));
+        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }
 
 } // namespace ctmd

--- a/ctmd/sum.hpp
+++ b/ctmd/sum.hpp
@@ -19,11 +19,11 @@ inline constexpr void sum_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <int64_t Axis, typename InType, typename OutType>
-inline constexpr void sum(InType &&In, OutType &&Out,
+template <int64_t Axis>
+inline constexpr void sum(auto &&In, auto &&Out,
                           const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto in = core::to_const_mdspan(std::forward<InType>(In));
-    const auto out = core::to_mdspan(std::forward<OutType>(Out));
+    const auto in = core::to_const_mdspan(std::forward<decltype(In)>(In));
+    const auto out = core::to_mdspan(std::forward<decltype(Out)>(Out));
 
     constexpr size_t in_rank = decltype(in)::rank();
     constexpr size_t rin_rank =
@@ -38,10 +38,10 @@ inline constexpr void sum(InType &&In, OutType &&Out,
         std::index_sequence<rin_rank, rin_rank - 1>{}, mpmode, in, out);
 }
 
-template <int64_t Axis, typename dtype = void, typename InType>
+template <int64_t Axis, typename dtype = void>
 [[nodiscard]] inline constexpr auto
-sum(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    const auto in = core::to_const_mdspan(std::forward<InType>(In));
+sum(auto &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    const auto in = core::to_const_mdspan(std::forward<decltype(In)>(In));
 
     constexpr size_t in_rank = decltype(in)::rank();
     constexpr size_t rin_rank =

--- a/ctmd/tan.hpp
+++ b/ctmd/tan.hpp
@@ -14,27 +14,26 @@ inline constexpr void tan_impl(const in_t &in, const out_t &out) noexcept {
 
 } // namespace detail
 
-template <typename InType, typename OutType>
-inline constexpr void tan(InType &&In, OutType &&Out,
+inline constexpr void tan(auto &&In, auto &&Out,
                           const MPMode mpmode = MPMode::NONE) noexcept {
     core::batch(
         [](auto &&...elems) {
             detail::tan_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)),
-        core::to_mdspan(std::forward<OutType>(Out)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
-template <typename dtype = void, typename InType>
+template <typename dtype = void>
 [[nodiscard]] inline constexpr auto
-tan(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+tan(auto &&In, const MPMode mpmode = MPMode::NONE) noexcept {
     return core::batch_out<dtype>(
         [](auto &&...elems) {
             detail::tan_impl(std::forward<decltype(elems)>(elems)...);
         },
         std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode,
-        core::to_const_mdspan(std::forward<InType>(In)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)));
 }
 
 } // namespace ctmd

--- a/ctmd/to_string.hpp
+++ b/ctmd/to_string.hpp
@@ -49,10 +49,9 @@ template <extents_c in_t>
     return str + ")";
 }
 
-template <typename InType>
-[[nodiscard]] inline std::string to_string(InType &&In) noexcept {
+[[nodiscard]] inline std::string to_string(auto &&In) noexcept {
     return detail::to_string_impl(
-        core::to_const_mdspan(std::forward<InType>(In)));
+        core::to_const_mdspan(std::forward<decltype(In)>(In)));
 }
 
 } // namespace ctmd

--- a/ctmd/zeros_like.hpp
+++ b/ctmd/zeros_like.hpp
@@ -4,16 +4,15 @@
 
 namespace ctmd {
 
-template <typename InType>
 [[nodiscard]] inline constexpr auto
-zeros_like(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    return ctmd::full_like(std::forward<InType>(In), 0, mpmode);
+zeros_like(auto &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    return ctmd::full_like(std::forward<decltype(In)>(In), 0, mpmode);
 }
 
-template <typename dtype, typename InType>
+template <typename dtype>
 [[nodiscard]] inline constexpr auto
-zeros_like(InType &&In, const MPMode mpmode = MPMode::NONE) noexcept {
-    return ctmd::full_like<dtype>(std::forward<InType>(In), 0, mpmode);
+zeros_like(auto &&In, const MPMode mpmode = MPMode::NONE) noexcept {
+    return ctmd::full_like<dtype>(std::forward<decltype(In)>(In), 0, mpmode);
 }
 
 } // namespace ctmd


### PR DESCRIPTION
This pull request introduces a significant refactor to simplify and modernize the codebase by replacing explicit template type declarations with `auto` in function templates. This change improves code readability, reduces verbosity, and enhances the flexibility of the functions. Additionally, a minor change was made to the `benchmarks/isclose/none/source.hpp` file to update a method name for consistency.

### Key Changes:

#### Template Simplification:
1. **Generalized Function Templates with `auto`:**
   - Replaced explicit type parameters (e.g., `InType`, `OutType`) with `auto` in function templates across multiple files, such as `ctmd/absolute.hpp`, `ctmd/add.hpp`, `ctmd/atan2.hpp`, `ctmd/clip.hpp`, `ctmd/cos.hpp`, `ctmd/deg2rad.hpp`, `ctmd/divide.hpp`, `ctmd/all.hpp`, `ctmd/allclose.hpp`, `ctmd/array_equal.hpp`, and `ctmd/array_equiv.hpp`. This change reduces verbosity and allows more flexible type inference. [[1]](diffhunk://#diff-aec17a41b7f74077877bb026f91dc326538e676f26f2fa1d8e60bcaf164f6a12L23-R42) [[2]](diffhunk://#diff-c9994732d1e6002884a7013c301398a806166350d007f6a41f26487c54e48f20L40-R52) [[3]](diffhunk://#diff-c9994732d1e6002884a7013c301398a806166350d007f6a41f26487c54e48f20L70-R81) [[4]](diffhunk://#diff-592c86312f2757d920815eaae4798cf967a8e3ae68acb5a55ec1f68ed8a0234dL8-R13) [[5]](diffhunk://#diff-401da45e6f66a8c2bf9ba9970d58a8982f9eb992ce3307c194be6d6f06ee0903L7-R10) [[6]](diffhunk://#diff-9c68f95409d4805beac6f78a05c0c825fede1dc1bc5a901bea730a10cc35eed5L8-R12) [[7]](diffhunk://#diff-92a1648264edfaada2ef3fc9e753431662713f50d60dd4eebd760f33234cf49dL21-R42) [[8]](diffhunk://#diff-5756e30dae44a8d7449b13438e9947cdf16b2b4495bfa5bcf96824a43ad0e9b2L27-R51) [[9]](diffhunk://#diff-1e1119355967fc8c0e0b6e3b592d77425acaea4f69277b82b2441de760202d67L16-R35) [[10]](diffhunk://#diff-17cb1195c19519259a657dda7fffdccf4f8f77a93b7f57a3ea7596d79196f30bL17-R36) [[11]](diffhunk://#diff-7564f72f8a9443c1cd1308c2fa40605660e81a06e847bbbac99ad231d70ef20eL7-R24) [[12]](diffhunk://#diff-9e21edfeacd67bf2681c5c915acf54197f1b6eba1f93c09da8f30d2c7708ab98L17-R38)

2. **Core Utilities (`ctmd/core/convert.hpp`):**
   - Updated utility functions like `to_mdspan`, `to_const_mdspan`, and `reshape` to use `auto` for parameter types, improving type inference and consistency. [[1]](diffhunk://#diff-341af9a1bd83cf86df2f7250201b1138d3ae226da7a4903298373aea64d4c48aL8-R12) [[2]](diffhunk://#diff-341af9a1bd83cf86df2f7250201b1138d3ae226da7a4903298373aea64d4c48aL38-R38) [[3]](diffhunk://#diff-341af9a1bd83cf86df2f7250201b1138d3ae226da7a4903298373aea64d4c48aL54-R55)

3. **Submdspan Utilities (`ctmd/core/submdspan.hpp`):**
   - Updated `submdspan`, `submdspan_with_space`, `submdspan_from_left`, and `submdspan_from_right` to use `auto` for input types, enabling more concise and flexible slicing operations.

#### Method Renaming:
4. **Renamed Method in Benchmark Code:**
   - Updated the method call from `md::isclose` to `md::isclose_to` in `benchmarks/isclose/none/source.hpp` for improved clarity and alignment with naming conventions.