### PR TITLE
implement copy_like

### DIFF
--- a/ctmd/ctmd.hpp
+++ b/ctmd/ctmd.hpp
@@ -15,6 +15,7 @@
 #include "ctmd_clip.hpp"
 #include "ctmd_concatenate.hpp"
 #include "ctmd_copy.hpp"
+#include "ctmd_copy_like.hpp"
 #include "ctmd_cos.hpp"
 #include "ctmd_deg2rad.hpp"
 #include "ctmd_divide.hpp"

--- a/ctmd/ctmd_copy_like.hpp
+++ b/ctmd/ctmd_copy_like.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "ctmd_copy.hpp"
+#include "ctmd_empty_like.hpp"
+
+namespace ctmd {
+
+[[nodiscard]] inline constexpr auto
+copy_like(auto &&In1, auto &&In2,
+          const ctmd::MPMode mpmode = ctmd::MPMode::NONE) noexcept {
+    auto out = ctmd::empty_like(std::forward<decltype(In1)>(In1));
+    ctmd::copy_to(std::forward<decltype(In2)>(In2), out, mpmode);
+    return out;
+}
+
+template <typename dtype>
+[[nodiscard]] inline constexpr auto
+copy_like(auto &&In1, auto &&In2,
+          const ctmd::MPMode mpmode = ctmd::MPMode::NONE) noexcept {
+    auto out = ctmd::empty_like<dtype>(std::forward<decltype(In1)>(In1));
+    ctmd::copy_to(std::forward<decltype(In2)>(In2), out, mpmode);
+    return out;
+}
+
+} // namespace ctmd


### PR DESCRIPTION
This pull request introduces a new utility function, `copy_like`, to the `ctmd` library and updates the header file to include it. The `copy_like` function facilitates creating a copy of one container with the shape of another, improving usability and consistency.

### New functionality:

* **Addition of `copy_like` function**: Introduced a new inline constexpr function `copy_like` in `ctmd_copy_like.hpp`. This function creates an output container with the same shape as the first input (`In1`) and copies the contents of the second input (`In2`) into it. It supports an optional `MPMode` parameter for specifying memory policy modes. An overloaded version of the function allows specifying the data type of the output container. (`[ctmd/ctmd_copy_like.hppR1-R25](diffhunk://#diff-a4f7278dadc75ac51168c28cc7d59db5c98104f4a8fb2e3412c6de5c214e2ed4R1-R25)`)

### Header file update:

* **Header inclusion**: Added `#include "ctmd_copy_like.hpp"` to `ctmd.hpp` to make the new `copy_like` function available as part of the `ctmd` library's public interface. (`[ctmd/ctmd.hppR18](diffhunk://#diff-b3b1a312d3bd628d2ee113ba7014a53ca7a0eef8b1979a2cb0ad5e7fbb1d5fd3R18)`)