### PR TITLE
Refactor batch

### DIFF
--- a/ctmd/core/ctmd_core_broadcast.hpp
+++ b/ctmd/core/ctmd_core_broadcast.hpp
@@ -425,9 +425,7 @@ create_out(std::index_sequence<uranks...>,
     }(std::make_index_sequence<sizeof...(ins_t) + sizeof...(uouts_exts_t)>{});
 }
 
-template <typename dtype = void, size_t... uranks, extents_c... uouts_exts_t,
-          mdspan_c... ins_t>
-    requires(sizeof...(uranks) == sizeof...(ins_t))
+template <typename dtype = void, extents_c... uouts_exts_t, mdspan_c... ins_t>
 [[nodiscard]] inline constexpr auto
 create_out(const std::tuple<uouts_exts_t...> &uouts_exts,
            const ins_t &...ins) noexcept {

--- a/ctmd/core/ctmd_core_broadcast.hpp
+++ b/ctmd/core/ctmd_core_broadcast.hpp
@@ -452,8 +452,6 @@ inline constexpr void batch(Func &&func, std::index_sequence<offsets...>,
              ur[Is])...};
     }(std::make_index_sequence<sizeof...(ins_t)>{});
 
-    auto ins_tuple = std::forward_as_tuple(ins...);
-
     constexpr bool no_branks = [&]<size_t... Is>(std::index_sequence<Is...>) {
         return ((br[Is] == 0) && ...);
     }(std::make_index_sequence<sizeof...(ins_t)>{});
@@ -463,6 +461,8 @@ inline constexpr void batch(Func &&func, std::index_sequence<offsets...>,
         std::forward<Func>(func)(ins...);
 
     } else {
+        auto ins_tuple = std::forward_as_tuple(ins...);
+
         constexpr bool possibly_same_bexts =
             [&]<size_t... Is>(std::index_sequence<Is...>) {
                 return ((br[Is] == br[0]) && ...);

--- a/ctmd/core/ctmd_core_broadcast.hpp
+++ b/ctmd/core/ctmd_core_broadcast.hpp
@@ -365,6 +365,15 @@ template <typename dtype = void, size_t... uranks, extents_c uout_exts_t,
     }(std::make_index_sequence<sizeof...(ins_t) + 1>{});
 }
 
+template <typename dtype = void, extents_c uout_exts_t, mdspan_c... ins_t>
+[[nodiscard]] inline constexpr auto create_out(const uout_exts_t &uout_exts,
+                                               const ins_t &...ins) noexcept {
+    return [&]<size_t... Is>(std::index_sequence<Is...>) {
+        return create_out<dtype>(std::index_sequence<((void)Is, 0)...>{},
+                                 uout_exts, ins...);
+    }(std::make_index_sequence<sizeof...(ins_t)>{});
+}
+
 template <typename dtype = void, size_t... offsets, size_t... uranks,
           extents_c... uouts_exts_t, mdspan_c... ins_t>
     requires(sizeof...(offsets) == sizeof...(ins_t) + sizeof...(uouts_exts_t) &&
@@ -414,6 +423,18 @@ create_out(std::index_sequence<uranks...>,
                                  std::index_sequence<uranks...>{}, uouts_exts,
                                  ins...);
     }(std::make_index_sequence<sizeof...(ins_t) + sizeof...(uouts_exts_t)>{});
+}
+
+template <typename dtype = void, size_t... uranks, extents_c... uouts_exts_t,
+          mdspan_c... ins_t>
+    requires(sizeof...(uranks) == sizeof...(ins_t))
+[[nodiscard]] inline constexpr auto
+create_out(const std::tuple<uouts_exts_t...> &uouts_exts,
+           const ins_t &...ins) noexcept {
+    return [&]<size_t... Is>(std::index_sequence<Is...>) {
+        return create_out<dtype>(std::index_sequence<((void)Is, 0)...>{},
+                                 uouts_exts, ins...);
+    }(std::make_index_sequence<sizeof...(ins_t)>{});
 }
 
 template <typename Func, size_t... offsets, size_t... uranks, mdspan_c... ins_t>
@@ -529,6 +550,15 @@ inline constexpr void batch(Func &&func, std::index_sequence<uranks...>,
     }(std::make_index_sequence<sizeof...(ins_t)>{});
 }
 
+template <typename Func, mdspan_c... ins_t>
+inline constexpr void batch(Func &&func, const ctmd::MPMode mpmode,
+                            const ins_t &...ins) noexcept {
+    [&]<size_t... Is>(std::index_sequence<Is...>) {
+        batch(std::forward<Func>(func), std::index_sequence<((void)Is, 0)...>{},
+              mpmode, ins...);
+    }(std::make_index_sequence<sizeof...(ins_t)>{});
+}
+
 template <typename dtype = void, typename Func, size_t... offsets,
           size_t... uranks, extents_c uout_exts_t, mdspan_c... ins_t>
     requires(sizeof...(offsets) == sizeof...(ins_t) + 1 &&
@@ -560,6 +590,18 @@ batch_out(Func &&func, std::index_sequence<uranks...>,
             std::forward<Func>(func), std::index_sequence<((void)Is, 0)...>{},
             std::index_sequence<uranks...>{}, uout_exts, mpmode, ins...);
     }(std::make_index_sequence<sizeof...(ins_t) + 1>{});
+}
+
+template <typename dtype = void, typename Func, extents_c uout_exts_t,
+          mdspan_c... ins_t>
+[[nodiscard]] inline constexpr auto
+batch_out(Func &&func, const uout_exts_t &uout_exts, const ctmd::MPMode mpmode,
+          const ins_t &...ins) noexcept {
+    return [&]<size_t... Is>(std::index_sequence<Is...>) {
+        return batch_out<dtype>(std::forward<Func>(func),
+                                std::index_sequence<((void)Is, 0)...>{},
+                                uout_exts, mpmode, ins...);
+    }(std::make_index_sequence<sizeof...(ins_t)>{});
 }
 
 template <typename dtype = void, typename Func, size_t... offsets,
@@ -598,6 +640,18 @@ batch_out(Func &&func, std::index_sequence<uranks...>,
             std::forward<Func>(func), std::index_sequence<((void)Is, 0)...>{},
             std::index_sequence<uranks...>{}, uouts_exts, mpmode, ins...);
     }(std::make_index_sequence<sizeof...(ins_t) + sizeof...(uouts_exts_t)>{});
+}
+
+template <typename dtype = void, typename Func, extents_c... uouts_exts_t,
+          mdspan_c... ins_t>
+[[nodiscard]] inline constexpr auto
+batch_out(Func &&func, const std::tuple<uouts_exts_t...> &uouts_exts,
+          const ctmd::MPMode mpmode, const ins_t &...ins) noexcept {
+    return [&]<size_t... Is>(std::index_sequence<Is...>) {
+        return batch_out<dtype>(std::forward<Func>(func),
+                                std::index_sequence<((void)Is, 0)...>{},
+                                uouts_exts, mpmode, ins...);
+    }(std::make_index_sequence<sizeof...(ins_t)>{});
 }
 
 } // namespace core

--- a/ctmd/creation/ctmd_copy.hpp
+++ b/ctmd/creation/ctmd_copy.hpp
@@ -20,8 +20,7 @@ copy_to(auto &&In, auto &&Out,
         [](auto &&...elems) {
             detail::copy_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In)>(In)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
@@ -32,7 +31,7 @@ copy(auto &&In, const ctmd::MPMode mpmode = ctmd::MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::copy_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In)>(In)));
 }
 

--- a/ctmd/creation/ctmd_fill.hpp
+++ b/ctmd/creation/ctmd_fill.hpp
@@ -20,8 +20,7 @@ fill(auto &&In, const auto &val,
         [&](auto &&...elems) {
             detail::fill_impl(std::forward<decltype(elems)>(elems)..., val);
         },
-        std::index_sequence<0>{}, mpmode,
-        core::to_mdspan(std::forward<decltype(In)>(In)));
+        mpmode, core::to_mdspan(std::forward<decltype(In)>(In)));
 }
 
 } // namespace ctmd

--- a/ctmd/logic/ctmd_equal.hpp
+++ b/ctmd/logic/ctmd_equal.hpp
@@ -21,8 +21,7 @@ equal_to(auto &&In1, auto &&In2, auto &&Out,
         [](auto &&...elems) {
             detail::equal_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
@@ -35,7 +34,7 @@ equal(auto &&In1, auto &&In2,
         [](auto &&...elems) {
             detail::equal_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }

--- a/ctmd/logic/ctmd_greater.hpp
+++ b/ctmd/logic/ctmd_greater.hpp
@@ -21,8 +21,7 @@ greater_to(auto &&In1, auto &&In2, auto &&Out,
         [](auto &&...elems) {
             detail::greater_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
@@ -35,7 +34,7 @@ greater(auto &&In1, auto &&In2,
         [](auto &&...elems) {
             detail::greater_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }

--- a/ctmd/logic/ctmd_greater_equal.hpp
+++ b/ctmd/logic/ctmd_greater_equal.hpp
@@ -21,8 +21,7 @@ greater_equal_to(auto &&In1, auto &&In2, auto &&Out,
         [](auto &&...elems) {
             detail::greater_equal_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
@@ -35,7 +34,7 @@ greater_equal(auto &&In1, auto &&In2,
         [](auto &&...elems) {
             detail::greater_equal_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }

--- a/ctmd/logic/ctmd_isclose.hpp
+++ b/ctmd/logic/ctmd_isclose.hpp
@@ -27,8 +27,7 @@ isclose_to(auto &&In1, auto &&In2, auto &&Out, const double &rtol = 1e-05,
             detail::isclose_impl(std::forward<decltype(elems)>(elems)..., rtol,
                                  atol);
         },
-        std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
@@ -43,7 +42,7 @@ isclose(auto &&In1, auto &&In2, const double &rtol = 1e-05,
             detail::isclose_impl(std::forward<decltype(elems)>(elems)..., rtol,
                                  atol);
         },
-        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }

--- a/ctmd/logic/ctmd_less.hpp
+++ b/ctmd/logic/ctmd_less.hpp
@@ -21,8 +21,7 @@ less_to(auto &&In1, auto &&In2, auto &&Out,
         [](auto &&...elems) {
             detail::less_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
@@ -35,7 +34,7 @@ less(auto &&In1, auto &&In2,
         [](auto &&...elems) {
             detail::less_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }

--- a/ctmd/logic/ctmd_less_equal.hpp
+++ b/ctmd/logic/ctmd_less_equal.hpp
@@ -21,8 +21,7 @@ less_equal_to(auto &&In1, auto &&In2, auto &&Out,
         [](auto &&...elems) {
             detail::less_equal_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
@@ -35,7 +34,7 @@ less_equal(auto &&In1, auto &&In2,
         [](auto &&...elems) {
             detail::less_equal_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }

--- a/ctmd/logic/ctmd_not_equal.hpp
+++ b/ctmd/logic/ctmd_not_equal.hpp
@@ -21,8 +21,7 @@ not_equal_to(auto &&In1, auto &&In2, auto &&Out,
         [](auto &&...elems) {
             detail::not_equal_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
@@ -35,7 +34,7 @@ not_equal(auto &&In1, auto &&In2,
         [](auto &&...elems) {
             detail::not_equal_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }

--- a/ctmd/math/ctmd_absolute.hpp
+++ b/ctmd/math/ctmd_absolute.hpp
@@ -27,8 +27,7 @@ absolute_to(auto &&In, auto &&Out,
         [](auto &&...elems) {
             detail::absolute_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In)>(In)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
@@ -39,7 +38,7 @@ absolute(auto &&In, const ctmd::MPMode mpmode = ctmd::MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::absolute_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In)>(In)));
 }
 

--- a/ctmd/math/ctmd_add.hpp
+++ b/ctmd/math/ctmd_add.hpp
@@ -47,8 +47,7 @@ add_to(auto &&In1, auto &&In2, auto &&Out,
         [](auto &&...elems) {
             detail::add_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
@@ -78,7 +77,7 @@ add(auto &&In1, auto &&In2,
         [](auto &&...elems) {
             detail::add_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }

--- a/ctmd/math/ctmd_atan2.hpp
+++ b/ctmd/math/ctmd_atan2.hpp
@@ -25,8 +25,7 @@ atan2_to(auto &&In1, auto &&In2, auto &&Out,
         [](auto &&...elems) {
             detail::atan2_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
@@ -39,7 +38,7 @@ atan2(auto &&In1, auto &&In2,
         [](auto &&...elems) {
             detail::atan2_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }

--- a/ctmd/math/ctmd_clip.hpp
+++ b/ctmd/math/ctmd_clip.hpp
@@ -31,8 +31,7 @@ clip_to(auto &&In, auto &&Min, auto &&Max, auto &&Out,
         [](auto &&...elems) {
             detail::clip_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In)>(In)),
         core::to_const_mdspan(std::forward<decltype(Min)>(Min)),
         core::to_const_mdspan(std::forward<decltype(Max)>(Max)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
@@ -46,7 +45,7 @@ clip(auto &&In, auto &&Min, auto &&Max,
         [](auto &&...elems) {
             detail::clip_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In)>(In)),
         core::to_const_mdspan(std::forward<decltype(Min)>(Min)),
         core::to_const_mdspan(std::forward<decltype(Max)>(Max)));

--- a/ctmd/math/ctmd_cos.hpp
+++ b/ctmd/math/ctmd_cos.hpp
@@ -21,8 +21,7 @@ cos_to(auto &&In, auto &&Out,
         [](auto &&...elems) {
             detail::cos_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In)>(In)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
@@ -33,7 +32,7 @@ cos(auto &&In, const ctmd::MPMode mpmode = ctmd::MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::cos_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In)>(In)));
 }
 

--- a/ctmd/math/ctmd_divide.hpp
+++ b/ctmd/math/ctmd_divide.hpp
@@ -21,8 +21,7 @@ divide_to(auto &&In1, auto &&In2, auto &&Out,
         [](auto &&...elems) {
             detail::divide_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
@@ -35,7 +34,7 @@ divide(auto &&In1, auto &&In2,
         [](auto &&...elems) {
             detail::divide_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }

--- a/ctmd/math/ctmd_maximum.hpp
+++ b/ctmd/math/ctmd_maximum.hpp
@@ -22,8 +22,7 @@ maximum_to(auto &&In1, auto &&In2, auto &&Out,
         [](auto &&...elems) {
             detail::maximum_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
@@ -36,7 +35,7 @@ maximum(auto &&In1, auto &&In2,
         [](auto &&...elems) {
             detail::maximum_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }

--- a/ctmd/math/ctmd_minimum.hpp
+++ b/ctmd/math/ctmd_minimum.hpp
@@ -22,8 +22,7 @@ minimum_to(auto &&In1, auto &&In2, auto &&Out,
         [](auto &&...elems) {
             detail::minimum_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
@@ -36,7 +35,7 @@ minimum(auto &&In1, auto &&In2,
         [](auto &&...elems) {
             detail::minimum_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }

--- a/ctmd/math/ctmd_multiply.hpp
+++ b/ctmd/math/ctmd_multiply.hpp
@@ -21,8 +21,7 @@ multiply_to(auto &&In1, auto &&In2, auto &&Out,
         [](auto &&...elems) {
             detail::multiply_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
@@ -35,7 +34,7 @@ multiply(auto &&In1, auto &&In2,
         [](auto &&...elems) {
             detail::multiply_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }

--- a/ctmd/math/ctmd_negative.hpp
+++ b/ctmd/math/ctmd_negative.hpp
@@ -20,8 +20,7 @@ negative_to(auto &&In, auto &&Out,
         [](auto &&...elems) {
             detail::negative_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In)>(In)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
@@ -32,7 +31,7 @@ negative(auto &&In, const ctmd::MPMode mpmode = ctmd::MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::negative_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In)>(In)));
 }
 

--- a/ctmd/math/ctmd_sign.hpp
+++ b/ctmd/math/ctmd_sign.hpp
@@ -20,8 +20,7 @@ sign_to(auto &&In, auto &&Out,
         [](auto &&...elems) {
             detail::sign_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In)>(In)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
@@ -32,7 +31,7 @@ sign(auto &&In, const ctmd::MPMode mpmode = ctmd::MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::sign_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In)>(In)));
 }
 

--- a/ctmd/math/ctmd_sin.hpp
+++ b/ctmd/math/ctmd_sin.hpp
@@ -21,8 +21,7 @@ sin_to(auto &&In, auto &&Out,
         [](auto &&...elems) {
             detail::sin_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In)>(In)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
@@ -33,7 +32,7 @@ sin(auto &&In, const ctmd::MPMode mpmode = ctmd::MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::sin_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In)>(In)));
 }
 

--- a/ctmd/math/ctmd_sqrt.hpp
+++ b/ctmd/math/ctmd_sqrt.hpp
@@ -56,8 +56,7 @@ sqrt_to(auto &&In, auto &&Out,
         [](auto &&...elems) {
             detail::sqrt_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In)>(In)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
@@ -68,7 +67,7 @@ sqrt(auto &&In, const ctmd::MPMode mpmode = ctmd::MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::sqrt_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In)>(In)));
 }
 

--- a/ctmd/math/ctmd_subtract.hpp
+++ b/ctmd/math/ctmd_subtract.hpp
@@ -21,8 +21,7 @@ subtract_to(auto &&In1, auto &&In2, auto &&Out,
         [](auto &&...elems) {
             detail::subtract_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
@@ -35,7 +34,7 @@ subtract(auto &&In1, auto &&In2,
         [](auto &&...elems) {
             detail::subtract_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In1)>(In1)),
         core::to_const_mdspan(std::forward<decltype(In2)>(In2)));
 }

--- a/ctmd/math/ctmd_tan.hpp
+++ b/ctmd/math/ctmd_tan.hpp
@@ -21,8 +21,7 @@ tan_to(auto &&In, auto &&Out,
         [](auto &&...elems) {
             detail::tan_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0, 0>{}, mpmode,
-        core::to_const_mdspan(std::forward<decltype(In)>(In)),
+        mpmode, core::to_const_mdspan(std::forward<decltype(In)>(In)),
         core::to_mdspan(std::forward<decltype(Out)>(Out)));
 }
 
@@ -33,7 +32,7 @@ tan(auto &&In, const ctmd::MPMode mpmode = ctmd::MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::tan_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0>{}, ctmd::extents<uint8_t>{}, mpmode,
+        ctmd::extents<uint8_t>{}, mpmode,
         core::to_const_mdspan(std::forward<decltype(In)>(In)));
 }
 

--- a/ctmd/random/ctmd_random_rand.hpp
+++ b/ctmd/random/ctmd_random_rand.hpp
@@ -102,7 +102,7 @@ rand_to(auto &&In, const ctmd::MPMode mpmode = ctmd::MPMode::NONE) noexcept {
         [](auto &&...elems) {
             detail::rand_impl(std::forward<decltype(elems)>(elems)...);
         },
-        std::index_sequence<0>{}, mpmode, in);
+        mpmode, in);
 }
 
 template <floating_point_c T = float, extents_c exts_t = ctmd::extents<uint8_t>>

--- a/ctmd/random/ctmd_random_uniform.hpp
+++ b/ctmd/random/ctmd_random_uniform.hpp
@@ -27,7 +27,7 @@ uniform_to(auto &&In, const double &low = 0, const double &high = 1,
             in() = static_cast<const T>(high - low) * in() +
                    static_cast<const T>(low);
         },
-        std::index_sequence<0>{}, mpmode, in);
+        mpmode, in);
 }
 
 template <floating_point_c T = float, extents_c exts_t = ctmd::extents<uint8_t>>


### PR DESCRIPTION
This pull request refactors and extends the broadcasting and batch-processing utilities in the core of the CTMD library, while also simplifying logic and math operation wrappers. The main changes improve API usability by adding new overloads, removing unnecessary index sequences from public interfaces, and enhancing flexibility for handling input and output extents. These modifications make the codebase easier to use and maintain, and reduce boilerplate in higher-level operations.

### Core API extensions and improvements

* Added new overloads for `create_out` and `batch_out` in `ctmd/core/ctmd_core_broadcast.hpp` to support both single and tuple-based output extents, and to simplify invocation by removing the need for explicit index sequences in user code. Also added an overload for `batch` that takes only the mode and inputs. [[1]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749R368-R376) [[2]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749R428-R437) [[3]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749R551-R559) [[4]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749R593-R604) [[5]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749R643-R654)
* Moved creation of `ins_tuple` in the `batch` function to only occur when needed, improving efficiency and clarity. [[1]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749L434-L435) [[2]](diffhunk://#diff-f7219046feab60f7c94e6afe4afdd4728d5122ea2df54a5d9be1bb239ca69749R462-R463)

### Logic and math operation wrappers simplification

* Removed explicit index sequences from public wrappers in logic (`ctmd/logic/ctmd_equal.hpp`, `ctmd/logic/ctmd_greater.hpp`, `ctmd/logic/ctmd_greater_equal.hpp`, `ctmd/logic/ctmd_less.hpp`, `ctmd/logic/ctmd_less_equal.hpp`, `ctmd/logic/ctmd_not_equal.hpp`, `ctmd/logic/ctmd_isclose.hpp`) and math (`ctmd/math/ctmd_absolute.hpp`, `ctmd/math/ctmd_add.hpp`, `ctmd/math/ctmd_atan2.hpp`) files, making APIs more concise and user-friendly. [[1]](diffhunk://#diff-e7794d2a48b22d117cfa6c8b7082802877fa534a565d0d930da692045d78c8fbL24-R24) [[2]](diffhunk://#diff-e7794d2a48b22d117cfa6c8b7082802877fa534a565d0d930da692045d78c8fbL38-R37) [[3]](diffhunk://#diff-ae978256dbccaf0e599086d241a317621eaa78a8b8757bdee102256204f11c1cL24-R24) [[4]](diffhunk://#diff-ae978256dbccaf0e599086d241a317621eaa78a8b8757bdee102256204f11c1cL38-R37) [[5]](diffhunk://#diff-84771e68d3b5af1ff4d35c59d4370c02e4128de6b84d17ab26ff74ddff4bd164L24-R24) [[6]](diffhunk://#diff-84771e68d3b5af1ff4d35c59d4370c02e4128de6b84d17ab26ff74ddff4bd164L38-R37) [[7]](diffhunk://#diff-4f8ac48f3bcaef0902e1beb9d3f0c4a13a6af93f4eae6aaf3f538f46d7d439d7L24-R24) [[8]](diffhunk://#diff-4f8ac48f3bcaef0902e1beb9d3f0c4a13a6af93f4eae6aaf3f538f46d7d439d7L38-R37) [[9]](diffhunk://#diff-5968bf8c170d1bb53ae9345d5626e77679ae9f2f1fc6226580ff2cea239b2d31L24-R24) [[10]](diffhunk://#diff-5968bf8c170d1bb53ae9345d5626e77679ae9f2f1fc6226580ff2cea239b2d31L38-R37) [[11]](diffhunk://#diff-4cd237d32738daf8dbda9eba680a06dc0a015f232d8aefd713041f0aa1f9caacL24-R24) [[12]](diffhunk://#diff-4cd237d32738daf8dbda9eba680a06dc0a015f232d8aefd713041f0aa1f9caacL38-R37) [[13]](diffhunk://#diff-bec48adae423a568041f7f2497f52ebb98387f6f28bb2b9d5e5f7bd4deb55baaL30-R30) [[14]](diffhunk://#diff-bec48adae423a568041f7f2497f52ebb98387f6f28bb2b9d5e5f7bd4deb55baaL46-R45) [[15]](diffhunk://#diff-011b61a24fb0b49ac298d4897cb1eab0a51a5d5f48a17087452a8febbb5a1911L30-R30) [[16]](diffhunk://#diff-011b61a24fb0b49ac298d4897cb1eab0a51a5d5f48a17087452a8febbb5a1911L42-R41) [[17]](diffhunk://#diff-c97c5d61d5be7a85dd4d503065871aa80ad0ff46eb4d60e686f1d5f4810f450dL50-R50) [[18]](diffhunk://#diff-c97c5d61d5be7a85dd4d503065871aa80ad0ff46eb4d60e686f1d5f4810f450dL81-R80) [[19]](diffhunk://#diff-3f76582dfd43135af4bd5b4274ad2e11744dfbc2b6202e11a2ffce45a2ee53bdL28-R28) [[20]](diffhunk://#diff-3f76582dfd43135af4bd5b4274ad2e11744dfbc2b6202e11a2ffce45a2ee53bdL42-R41)

### Creation utilities update

* Updated `copy` and `fill` operations in `ctmd/creation/ctmd_copy.hpp` and `ctmd/creation/ctmd_fill.hpp` to remove explicit index sequences, streamlining their interfaces. [[1]](diffhunk://#diff-eca3fb22bb9f8597ab680434bdd94f258d045cbf8b0901ebca3703c5f839f9b2L23-R23) [[2]](diffhunk://#diff-eca3fb22bb9f8597ab680434bdd94f258d045cbf8b0901ebca3703c5f839f9b2L35-R34) [[3]](diffhunk://#diff-14dfd6d24a664570469e1ec6e58f75553c484bc796205111b15104c641438e48L23-R23)

These changes collectively improve the usability and maintainability of core CTMD APIs and related wrappers.